### PR TITLE
get documentation version from appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,18 +4,12 @@ pull_requests:
 image: Visual Studio 2017
 clone_depth: 100
 install:
-- cmd: >-
+- cmd: |
     set PATH=%PATH%;C:\Program Files (x86)\WiX Toolset v3.11\bin
-
     set GOPATH=C:\Users\appveyor
-
     set PATH=%PATH%;%GOPATH%\bin
-
     go get "github.com/Masterminds/semver"
-
-    pip install sphinx
-
-    pip install sphinx_rtd_theme
+    pip install sphinx sphinx_rtd_theme pyyaml
 
 build_script:
 - ps: |

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -14,6 +14,7 @@
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
+import yaml
 
 # -- Project information -----------------------------------------------------
 
@@ -22,7 +23,7 @@ copyright = '2019, DCS-BIOS Contributors'
 author = 'DCS-BIOS Contributors'
 
 # The full version, including alpha/beta/rc tags
-release = 'v0.8.0'
+release = yaml.load(open("../appveyor.yml"))["version"].split("+")[0]
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
The current documentation has its version hardcoded to "v0.8.0". This changes conf.py to get it from appveyor.yml instead.