### PR TITLE
Release v0.8.2

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,20 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the doc/ directory with Sphinx
+sphinx:
+  configuration: doc/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: all
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.7
+  install:
+    - requirements: doc/requirements.txt
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,18 +4,12 @@ pull_requests:
 image: Visual Studio 2017
 clone_depth: 100
 install:
-- cmd: >-
+- cmd: |
     set PATH=%PATH%;C:\Program Files (x86)\WiX Toolset v3.11\bin
-
     set GOPATH=C:\Users\appveyor
-
     set PATH=%PATH%;%GOPATH%\bin
-
     go get "github.com/Masterminds/semver"
-
-    pip install sphinx
-
-    pip install sphinx_rtd_theme
+    pip install sphinx sphinx_rtd_theme pyyaml
 
 build_script:
 - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: v0.8.1+{build}
+version: v0.8.2+{build}
 pull_requests:
   do_not_increment_build_number: true
 image: Visual Studio 2017

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -14,6 +14,7 @@
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
+import yaml
 
 # -- Project information -----------------------------------------------------
 
@@ -22,7 +23,7 @@ copyright = '2019, DCS-BIOS Contributors'
 author = 'DCS-BIOS Contributors'
 
 # The full version, including alpha/beta/rc tags
-release = 'v0.8.0'
+release = yaml.load(open("../appveyor.yml"))["version"].split("+")[0]
 
 
 # -- General configuration ---------------------------------------------------

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -1,7 +1,7 @@
 Installing DCS-BIOS
 ===================
 
-Download and run the installer file for the `latest stable release <https://github.com/dcs-bios/dcs-bios/releases/latest/>`_ from GitHub.
+Download and run the installer (called DCS-BIOS-Hub-Setup-*version*.msi) for the `latest stable release <https://github.com/dcs-bios/dcs-bios/releases/latest/>`_ from GitHub.
 
 
 .. note::

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,0 +1,4 @@
+sphinx
+sphinx_rtd_theme
+pyyaml
+

--- a/src/hub-backend/dcssetup/dcssetup_windows.go
+++ b/src/hub-backend/dcssetup/dcssetup_windows.go
@@ -252,6 +252,7 @@ func createProfileSubdir(profileDir string, subdirName string, logBuffer io.Writ
 	stat, err := os.Stat(fullSubdirPath)
 	if err != nil {
 		// does not exist
+		fmt.Fprintf(logBuffer, "creating directory: %s\n", fullSubdirPath)
 		err = os.Mkdir(fullSubdirPath, 0777)
 		if err != nil {
 			fmt.Fprintf(logBuffer, "error: could not create directory %s: %v\n", fullSubdirPath, err)
@@ -273,7 +274,7 @@ func SetupExportLua(profileDir string, shouldBeInstalled bool) (ok bool, logMess
 	// assert that profileDir exists and is a directory
 	stat, err := os.Stat(profileDir)
 	if err != nil || !stat.IsDir() {
-		fmt.Fprintf(logBuffer, "error: not a directory: %s\n", profileDir)
+		fmt.Fprintf(logBuffer, "error: profile directory does not exist, please start and exit DCS and try again: %s\n", profileDir)
 		return false, logBuffer.String()
 	}
 
@@ -287,6 +288,7 @@ func SetupExportLua(profileDir string, shouldBeInstalled bool) (ok bool, logMess
 	var existingExportLuaReader io.Reader
 	exportLuaFilePath := filepath.Join(profileDir, "Scripts", "Export.lua")
 	stat, err = os.Stat(exportLuaFilePath)
+
 	if err != nil {
 		// Export.lua does not exist yet
 		existingExportLuaReader = &bytes.Buffer{}
@@ -300,10 +302,6 @@ func SetupExportLua(profileDir string, shouldBeInstalled bool) (ok bool, logMess
 
 	// try setup
 	newExportLuaContent := GetModifiedExportLua(existingExportLuaReader, shouldBeInstalled, logBuffer)
-	if err != nil {
-		fmt.Fprintf(logBuffer, "error while generating new Export.lua content: %v\n", err)
-		return false, logBuffer.String()
-	}
 	file, err := os.Create(exportLuaFilePath)
 	if err != nil {
 		fmt.Fprintf(logBuffer, "error: could not open Export.lua for writing: %v\n", err)
@@ -338,18 +336,25 @@ func uninstallHook(profileDir string, hookDef *hookDefinition, logBuffer io.Writ
 	}
 	err = os.Remove(hookFile)
 	if err != nil {
-		fmt.Fprint(logBuffer, "error: could not delete %s: %v\n", hookFile, err)
+		fmt.Fprintf(logBuffer, "error: could not delete %s: %v\n", hookFile, err)
 		return false
 	}
 	fmt.Fprintf(logBuffer, "deleted: %s\n", hookFile)
 	return true
 }
 func installHook(profileDir string, hookDefinition *hookDefinition, logBuffer io.Writer) bool {
+	// assert that profileDir exists and is a directory
+	stat, err := os.Stat(profileDir)
+	if err != nil || !stat.IsDir() {
+		fmt.Fprintf(logBuffer, "error: profile directory does not exist, please start and exit DCS and try again: %s\n", profileDir)
+		return false
+	}
+
 	uninstallHook(profileDir, hookDefinition, logBuffer)
 	if !createProfileSubdir(profileDir, "Scripts", logBuffer) {
 		return false
 	}
-	if !createProfileSubdir(profileDir, "Hooks", logBuffer) {
+	if !createProfileSubdir(profileDir, "Scripts\\Hooks", logBuffer) {
 		return false
 	}
 	hookFile := filepath.Join(profileDir, "Scripts", "Hooks", hookDefinition.filename)

--- a/src/hub-backend/dcssetup/dcssetup_windows.go
+++ b/src/hub-backend/dcssetup/dcssetup_windows.go
@@ -53,6 +53,9 @@ func RegisterApi(jsonAPI *jsonapi.JsonApi) {
 
 // GetInstalledModulesList returns a list of all installed DCS: World modules.
 func GetInstalledModulesList() []string {
+	var folderNamesToModuleDefinitionNames = map[string][]string{
+		"FA-18C": {"FA-18C_hornet"},
+	}
 	moduleSet := make(map[string]struct{}, 0)
 
 	scanDcsInstallDir := func(path string) {
@@ -63,6 +66,11 @@ func GetInstalledModulesList() []string {
 		for _, fi := range fileinfoList {
 			if fi.IsDir() {
 				moduleSet[strings.ToLower(fi.Name())] = struct{}{}
+			}
+			if otherDefinitonNames, ok := folderNamesToModuleDefinitionNames[fi.Name()]; ok {
+				for _, name := range otherDefinitonNames {
+					moduleSet[strings.ToLower(name)] = struct{}{}
+				}
 			}
 		}
 	}

--- a/src/hub-frontend/package-lock.json
+++ b/src/hub-frontend/package-lock.json
@@ -1836,6 +1836,11 @@
       "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
     },
+    "array-flat-polyfill": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/array-flat-polyfill/-/array-flat-polyfill-1.0.1.tgz",
+      "integrity": "sha512-hfJmKupmQN0lwi0xG6FQ5U8Rd97RnIERplymOv/qpq8AoNKPPAnxJadjFA23FNWm88wykh9HmpLJUUwUtNU/iw=="
+    },
     "array-flatten": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",

--- a/src/hub-frontend/package.json
+++ b/src/hub-frontend/package.json
@@ -11,6 +11,7 @@
     "@types/react-router-dom": "^5.1.0",
     "@types/react-router-hash-link": "^1.2.1",
     "@types/websocket": "0.0.40",
+    "array-flat-polyfill": "^1.0.1",
     "codemirror": "^5.49.0",
     "react": "^16.10.2",
     "react-codemirror2": "^6.0.0",

--- a/src/hub-frontend/src/index.js
+++ b/src/hub-frontend/src/index.js
@@ -1,3 +1,5 @@
+import 'array-flat-polyfill';
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import './index.css';

--- a/src/installer/product.wxs
+++ b/src/installer/product.wxs
@@ -49,11 +49,16 @@
                     </Component>
                 </Directory>
             </Directory>
+    
+            <Component Id="CMP_InstallDirRegistryKey" Guid="85307F57-4580-46FA-92A8-E989D26F5E0C">
+                <RegistryValue Root="HKLM" Key="Software\DCS-BIOS\DCS-BIOS Hub" Name="Path" Type="string" Value="[INSTALLDIR]" KeyPath="yes"/>
+            </Component>
         </Directory>
 
         <Feature Id="DcsBios" Title="DCS-BIOS" Level="1" Absent="disallow">
             <ComponentRef Id="CMP_mainexe"/>
             <ComponentRef Id="CMP_StartMenuShortcut"/>
+            <ComponentRef Id="CMP_InstallDirRegistryKey"/>
             <ComponentGroupRef Id="CMP_DcsLuaFiles"/>
             <ComponentGroupRef Id="CMP_ControlReferenceJsonFiles"/>
             <ComponentGroupRef Id="CMP_FrontendApp"/>


### PR DESCRIPTION
* the PDF download of the documentation on readthedocs.org now shows the correct version number
* the web interface of the DCS-BIOS Hub should now work on Internet Explorer and Edge browsers
* the FA-18C Hornet is correctly recognized as an installed module
* the automatic setup of Lua scripts no longer fails if the "Scripts" and/or "Hooks" directories do not exist in the user profile
* improved error message when the user profile does not exist at all
* the installer now saves the install location in the Windows registry at HKLM\Software\DCS-BIOS\DCS-BIOS Hub\Path. Third-party software could use this registry key to locate the control reference JSON files.
* the installation documentation now explicitly mentions the name of the installer file