### PR TITLE
Release v0.8.3

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: v0.8.2+{build}
+version: v0.8.3+{build}
 pull_requests:
   do_not_increment_build_number: true
 image: Visual Studio 2017

--- a/src/control-reference-json/FA-18C_hornet.json
+++ b/src/control-reference-json/FA-18C_hornet.json
@@ -9636,26 +9636,15 @@
                                                                                                    "physical_variant": "push_button"
                                                                                             },
                                                                 "UFC_COMM1_CHANNEL_SELECT": {
-                                                                                                 "api_variant": "multiturn",
                                                                                                     "category": "Up Front Controller (UFC)",
-                                                                                                "control_type": "analog_dial",
+                                                                                                "control_type": "fixed_step_dial",
                                                                                                  "description": "COMM 1 Channel Select Knob",
                                                                                                   "identifier": "UFC_COMM1_CHANNEL_SELECT",
                                                                                                       "inputs": [ {
-                                                                                                                       "description": "turn the dial left or right",
-                                                                                                                         "interface": "variable_step",
-                                                                                                                         "max_value": 65535,
-                                                                                                                    "suggested_step": 3200
+                                                                                                                    "description": "turn left or right",
+                                                                                                                      "interface": "fixed_step"
                                                                                                                 } ],
-                                                                                                     "outputs": [ {
-                                                                                                                        "address": 29728,
-                                                                                                                    "description": "the rotation of the knob in the cockpit (not the value that is controlled by this knob!)",
-                                                                                                                           "mask": 65535,
-                                                                                                                      "max_value": 65535,
-                                                                                                                       "shift_by": 0,
-                                                                                                                         "suffix": "_KNOB_POS",
-                                                                                                                           "type": "integer"
-                                                                                                                } ]
+                                                                                                     "outputs": [  ]
                                                                                             },
                                                                        "UFC_COMM1_DISPLAY": {
                                                                                                     "category": "Up Front Controller (UFC)",
@@ -9727,26 +9716,15 @@
                                                                                                                 } ]
                                                                                             },
                                                                 "UFC_COMM2_CHANNEL_SELECT": {
-                                                                                                 "api_variant": "multiturn",
                                                                                                     "category": "Up Front Controller (UFC)",
-                                                                                                "control_type": "analog_dial",
+                                                                                                "control_type": "fixed_step_dial",
                                                                                                  "description": "COMM 2 Channel Select Knob",
                                                                                                   "identifier": "UFC_COMM2_CHANNEL_SELECT",
                                                                                                       "inputs": [ {
-                                                                                                                       "description": "turn the dial left or right",
-                                                                                                                         "interface": "variable_step",
-                                                                                                                         "max_value": 65535,
-                                                                                                                    "suggested_step": 3200
+                                                                                                                    "description": "turn left or right",
+                                                                                                                      "interface": "fixed_step"
                                                                                                                 } ],
-                                                                                                     "outputs": [ {
-                                                                                                                        "address": 29730,
-                                                                                                                    "description": "the rotation of the knob in the cockpit (not the value that is controlled by this knob!)",
-                                                                                                                           "mask": 65535,
-                                                                                                                      "max_value": 65535,
-                                                                                                                       "shift_by": 0,
-                                                                                                                         "suffix": "_KNOB_POS",
-                                                                                                                           "type": "integer"
-                                                                                                                } ]
+                                                                                                     "outputs": [  ]
                                                                                             },
                                                                        "UFC_COMM2_DISPLAY": {
                                                                                                     "category": "Up Front Controller (UFC)",

--- a/src/dcs-lua/lib/FA-18C_hornet.lua
+++ b/src/dcs-lua/lib/FA-18C_hornet.lua
@@ -522,8 +522,11 @@ definePushButton("UFC_ENT", 25, 3029, 122, "Up Front Controller (UFC)", "Keyboar
 definePotentiometer("UFC_COMM1_VOL", 25, 3030, 108, {0, 1}, "Up Front Controller (UFC)", "COMM 1 Volume Control Knob")
 definePotentiometer("UFC_COMM2_VOL", 25, 3031, 123, {0, 1}, "Up Front Controller (UFC)", "COMM 2 Volume Control Knob")
 definePotentiometer("UFC_BRT", 25, 3032, 109, {0, 1}, "Up Front Controller (UFC)", "Brightness Control Knob")
+
 defineRotary("UFC_COMM1_CHANNEL_SELECT", 25, 3033, 124, "Up Front Controller (UFC)", "COMM 1 Channel Select Knob")
 defineRotary("UFC_COMM2_CHANNEL_SELECT", 25, 3034, 126, "Up Front Controller (UFC)", "COMM 2 Channel Select Knob")
+BIOS.util.defineFixedStepInput("UFC_COMM1_CHANNEL_SELECT", 25, 3033, {-0.2, 0.2}, "Up Front Controller (UFC)", "COMM 1 Channel Select Knob")
+BIOS.util.defineFixedStepInput("UFC_COMM2_CHANNEL_SELECT", 25, 3034, {-0.2, 0.2}, "Up Front Controller (UFC)", "COMM 2 Channel Select Knob")
 
 local UFC_Comm1Display = ""
 local UFC_Comm2Display = ""
@@ -540,6 +543,18 @@ local UFC_OptionDisplay5 = ""
 local UFC_ScratchPadNumberDisplay = ""
 local UFC_ScratchPadString1Display = ""
 local UFC_ScratchPadString2Display = ""
+
+local function processUfcTwoDigitDisplay(s)
+	if s == "_" then
+		s = "--"
+	end
+	s = s:gsub("^`", "1")
+	s = s:gsub("^~", "2")
+	if s:len() == 1 then
+		s = " " .. s
+	end
+	return s
+end
 
 moduleBeingDefined.exportHooks[#moduleBeingDefined.exportHooks+1] = function()
 	local ufc = parse_indication(6)
@@ -562,7 +577,9 @@ moduleBeingDefined.exportHooks[#moduleBeingDefined.exportHooks+1] = function()
 		return
 	end
 	UFC_Comm1Display 				= coerce_nil_to_string(ufc.UFC_Comm1Display)
+	UFC_Comm1Display = processUfcTwoDigitDisplay(UFC_Comm1Display)
 	UFC_Comm2Display 				= coerce_nil_to_string(ufc.UFC_Comm2Display)
+	UFC_Comm2Display = processUfcTwoDigitDisplay(UFC_Comm2Display)
 	UFC_OptionCueing1 				= coerce_nil_to_string(ufc.UFC_OptionCueing1)
 	UFC_OptionCueing2 				= coerce_nil_to_string(ufc.UFC_OptionCueing2)
 	UFC_OptionCueing3 				= coerce_nil_to_string(ufc.UFC_OptionCueing3)
@@ -574,8 +591,11 @@ moduleBeingDefined.exportHooks[#moduleBeingDefined.exportHooks+1] = function()
 	UFC_OptionDisplay4 				= coerce_nil_to_string(ufc.UFC_OptionDisplay4)
 	UFC_OptionDisplay5 				= coerce_nil_to_string(ufc.UFC_OptionDisplay5)
 	UFC_ScratchPadNumberDisplay 	= coerce_nil_to_string(ufc.UFC_ScratchPadNumberDisplay)
+	UFC_ScratchPadNumberDisplay = (" "):rep(8-UFC_ScratchPadNumberDisplay:len())..UFC_ScratchPadNumberDisplay
 	UFC_ScratchPadString1Display 	= coerce_nil_to_string(ufc.UFC_ScratchPadString1Display)
+	UFC_ScratchPadString1Display = processUfcTwoDigitDisplay(UFC_ScratchPadString1Display)
 	UFC_ScratchPadString2Display 	= coerce_nil_to_string(ufc.UFC_ScratchPadString2Display)
+	UFC_ScratchPadString2Display = processUfcTwoDigitDisplay(UFC_ScratchPadString2Display)
 end
 
 defineString("UFC_COMM1_DISPLAY", function() return UFC_Comm1Display end, 2, "Up Front Controller (UFC)", "Comm 1 Display")

--- a/src/hub-backend/go.mod
+++ b/src/hub-backend/go.mod
@@ -1,6 +1,7 @@
 module dcs-bios.a10c.de/dcs-bios-hub
 
 require (
+	github.com/andygrunwald/vdf v1.0.0
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/getlantern/context v0.0.0-20190109183933-c447772a6520 // indirect
 	github.com/getlantern/errors v0.0.0-20180829142810-e24b7f4ff7c7 // indirect

--- a/src/hub-backend/go.sum
+++ b/src/hub-backend/go.sum
@@ -1,3 +1,5 @@
+github.com/andygrunwald/vdf v1.0.0 h1:2HuC85EVF1Sm1bwKH8tiyucny2qzf9GSjB3flsdqoM4=
+github.com/andygrunwald/vdf v1.0.0/go.mod h1:qi5jZfY3lrHXbibKeC2MCEge1tOsLODBgOHoS+RbRLk=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/src/hub-backend/jsonapi/jsonapi.go
+++ b/src/hub-backend/jsonapi/jsonapi.go
@@ -160,7 +160,7 @@ func (api *JsonApi) HandleApiCall(envelopeJsonData []byte, followupMessagesJson 
 	handlerFunc, ok := api.handlerFunctions[envelope.DataType]
 	if !ok {
 		close(responseJsonChannel)
-		return responseJsonChannel, errors.New("jsonapi: HandleApiCall: no handlerFunc for message type" + envelope.DataType)
+		return responseJsonChannel, errors.New("jsonapi: HandleApiCall: no handlerFunc for message type " + envelope.DataType)
 	}
 	// we know that handlerFunc expects 3 parameters and has Kind reflect.Func
 	// assert that the first argument type matches the type of the inital message


### PR DESCRIPTION
* FA-18C: fix COMM1 and COMM2 channel preset displays when the first digit is "1" or "2"
* FA-18C: right-justify UFC scratchpad display
* Fix control reference communication in Edge browser
* The automatic setup now detects DCS: World if it was installed via Steam