### PR TITLE
Release v0.8.4

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: v0.8.3+{build}
+version: v0.8.4+{build}
 pull_requests:
   do_not_increment_build_number: true
 image: Visual Studio 2017

--- a/src/control-reference-json/A-10C.json
+++ b/src/control-reference-json/A-10C.json
@@ -19,7 +19,7 @@
                                                                                          } ],
                                                                   "momentary_positions": "none",
                                                                               "outputs": [ {
-                                                                                                 "address": 4348,
+                                                                                                 "address": 4346,
                                                                                              "description": "selector position",
                                                                                                     "mask": 16384,
                                                                                                "max_value": 1,
@@ -48,7 +48,7 @@
                                                                                          } ],
                                                                   "momentary_positions": "none",
                                                                               "outputs": [ {
-                                                                                                 "address": 4348,
+                                                                                                 "address": 4346,
                                                                                              "description": "selector position",
                                                                                                     "mask": 32768,
                                                                                                "max_value": 1,
@@ -73,7 +73,7 @@
                                                                                          } ],
                                                                   "momentary_positions": "none",
                                                                               "outputs": [ {
-                                                                                                 "address": 4348,
+                                                                                                 "address": 4346,
                                                                                              "description": "selector position",
                                                                                                     "mask": 12288,
                                                                                                "max_value": 3,
@@ -95,7 +95,7 @@
                                                                                          } ],
                                                                   "momentary_positions": "first_and_last",
                                                                               "outputs": [ {
-                                                                                                 "address": 4348,
+                                                                                                 "address": 4346,
                                                                                              "description": "selector position",
                                                                                                     "mask": 3072,
                                                                                                "max_value": 2,
@@ -120,7 +120,7 @@
                                                                                          } ],
                                                                   "momentary_positions": "none",
                                                                               "outputs": [ {
-                                                                                                 "address": 4348,
+                                                                                                 "address": 4346,
                                                                                              "description": "selector position",
                                                                                                     "mask": 768,
                                                                                                "max_value": 2,
@@ -244,7 +244,7 @@
                                                                                            "suggested_step": 3200
                                                                                        } ],
                                                                             "outputs": [ {
-                                                                                               "address": 4448,
+                                                                                               "address": 4446,
                                                                                            "description": "position of the potentiometer",
                                                                                                   "mask": 65535,
                                                                                              "max_value": 65535,
@@ -334,7 +334,7 @@
                                                                                                } ],
                                                                         "momentary_positions": "none",
                                                                                     "outputs": [ {
-                                                                                                       "address": 4330,
+                                                                                                       "address": 4328,
                                                                                                    "description": "selector position",
                                                                                                           "mask": 1536,
                                                                                                      "max_value": 2,
@@ -363,7 +363,7 @@
                                                                                                } ],
                                                                         "momentary_positions": "none",
                                                                                     "outputs": [ {
-                                                                                                       "address": 4330,
+                                                                                                       "address": 4328,
                                                                                                    "description": "selector position",
                                                                                                           "mask": 8192,
                                                                                                      "max_value": 1,
@@ -388,7 +388,7 @@
                                                                                                } ],
                                                                         "momentary_positions": "none",
                                                                                     "outputs": [ {
-                                                                                                       "address": 4330,
+                                                                                                       "address": 4328,
                                                                                                    "description": "selector position",
                                                                                                           "mask": 48,
                                                                                                      "max_value": 2,
@@ -417,7 +417,7 @@
                                                                                                } ],
                                                                         "momentary_positions": "none",
                                                                                     "outputs": [ {
-                                                                                                       "address": 4330,
+                                                                                                       "address": 4328,
                                                                                                    "description": "selector position",
                                                                                                           "mask": 2048,
                                                                                                      "max_value": 1,
@@ -446,7 +446,7 @@
                                                                                                } ],
                                                                         "momentary_positions": "none",
                                                                                     "outputs": [ {
-                                                                                                       "address": 4330,
+                                                                                                       "address": 4328,
                                                                                                    "description": "selector position",
                                                                                                           "mask": 4096,
                                                                                                      "max_value": 1,
@@ -471,7 +471,7 @@
                                                                                                } ],
                                                                         "momentary_positions": "none",
                                                                                     "outputs": [ {
-                                                                                                       "address": 4336,
+                                                                                                       "address": 4334,
                                                                                                    "description": "selector position",
                                                                                                           "mask": 3,
                                                                                                      "max_value": 2,
@@ -500,7 +500,7 @@
                                                                                                } ],
                                                                         "momentary_positions": "none",
                                                                                     "outputs": [ {
-                                                                                                       "address": 4330,
+                                                                                                       "address": 4328,
                                                                                                    "description": "selector position",
                                                                                                           "mask": 16384,
                                                                                                      "max_value": 1,
@@ -525,7 +525,7 @@
                                                                                                } ],
                                                                         "momentary_positions": "none",
                                                                                     "outputs": [ {
-                                                                                                       "address": 4330,
+                                                                                                       "address": 4328,
                                                                                                    "description": "selector position",
                                                                                                           "mask": 192,
                                                                                                      "max_value": 2,
@@ -550,7 +550,7 @@
                                                                                                } ],
                                                                         "momentary_positions": "none",
                                                                                     "outputs": [ {
-                                                                                                       "address": 4330,
+                                                                                                       "address": 4328,
                                                                                                    "description": "selector position",
                                                                                                           "mask": 12,
                                                                                                      "max_value": 2,
@@ -579,7 +579,7 @@
                                                                                                } ],
                                                                         "momentary_positions": "none",
                                                                                     "outputs": [ {
-                                                                                                       "address": 4330,
+                                                                                                       "address": 4328,
                                                                                                    "description": "selector position",
                                                                                                           "mask": 256,
                                                                                                      "max_value": 1,
@@ -693,11 +693,11 @@
                                                                                        } ],
                                                                 "momentary_positions": "none",
                                                                             "outputs": [ {
-                                                                                               "address": 4540,
+                                                                                               "address": 4538,
                                                                                            "description": "selector position",
-                                                                                                  "mask": 32,
+                                                                                                  "mask": 2,
                                                                                              "max_value": 1,
-                                                                                              "shift_by": 5,
+                                                                                              "shift_by": 1,
                                                                                                 "suffix": "",
                                                                                                   "type": "integer"
                                                                                        } ],
@@ -728,7 +728,7 @@
                                                                          "identifier": "AIRSPEED_MAX_IAS",
                                                                              "inputs": [  ],
                                                                             "outputs": [ {
-                                                                                               "address": 4802,
+                                                                                               "address": 4800,
                                                                                            "description": "gauge position",
                                                                                                   "mask": 65535,
                                                                                              "max_value": 65535,
@@ -833,9 +833,9 @@
                                                                                    "outputs": [ {
                                                                                                       "address": 4420,
                                                                                                   "description": "selector position",
-                                                                                                         "mask": 48,
+                                                                                                         "mask": 3,
                                                                                                     "max_value": 2,
-                                                                                                     "shift_by": 4,
+                                                                                                     "shift_by": 0,
                                                                                                        "suffix": "",
                                                                                                          "type": "integer"
                                                                                               } ],
@@ -848,7 +848,7 @@
                                                                          "identifier": "ALT_PNEU_FLAG",
                                                                              "inputs": [  ],
                                                                             "outputs": [ {
-                                                                                               "address": 4810,
+                                                                                               "address": 4808,
                                                                                            "description": "gauge position",
                                                                                                   "mask": 65535,
                                                                                              "max_value": 65535,
@@ -934,7 +934,7 @@
                                                                                            "suggested_step": 3200
                                                                                        } ],
                                                                             "outputs": [ {
-                                                                                               "address": 4422,
+                                                                                               "address": 4418,
                                                                                            "description": "the rotation of the knob in the cockpit (not the value that is controlled by this knob!)",
                                                                                                   "mask": 65535,
                                                                                              "max_value": 65535,
@@ -964,11 +964,11 @@
                                                                                           } ],
                                                                    "momentary_positions": "none",
                                                                                "outputs": [ {
-                                                                                                  "address": 4542,
+                                                                                                  "address": 4540,
                                                                                               "description": "selector position",
-                                                                                                     "mask": 16,
+                                                                                                     "mask": 1,
                                                                                                 "max_value": 1,
-                                                                                                 "shift_by": 4,
+                                                                                                 "shift_by": 0,
                                                                                                    "suffix": "",
                                                                                                      "type": "integer"
                                                                                           } ],
@@ -989,11 +989,11 @@
                                                                                           } ],
                                                                    "momentary_positions": "none",
                                                                                "outputs": [ {
-                                                                                                  "address": 4542,
+                                                                                                  "address": 4538,
                                                                                               "description": "selector position",
-                                                                                                     "mask": 3,
+                                                                                                     "mask": 12288,
                                                                                                 "max_value": 2,
-                                                                                                 "shift_by": 0,
+                                                                                                 "shift_by": 12,
                                                                                                    "suffix": "",
                                                                                                      "type": "integer"
                                                                                           } ],
@@ -1014,11 +1014,11 @@
                                                                                           } ],
                                                                    "momentary_positions": "none",
                                                                                "outputs": [ {
-                                                                                                  "address": 4542,
+                                                                                                  "address": 4538,
                                                                                               "description": "selector position",
-                                                                                                     "mask": 12,
+                                                                                                     "mask": 49152,
                                                                                                 "max_value": 2,
-                                                                                                 "shift_by": 2,
+                                                                                                 "shift_by": 14,
                                                                                                    "suffix": "",
                                                                                                      "type": "integer"
                                                                                           } ],
@@ -1046,11 +1046,11 @@
                                                                                             } ],
                                                                      "momentary_positions": "none",
                                                                                  "outputs": [ {
-                                                                                                    "address": 4436,
+                                                                                                    "address": 4440,
                                                                                                 "description": "selector position",
-                                                                                                       "mask": 16,
+                                                                                                       "mask": 1,
                                                                                                   "max_value": 1,
-                                                                                                   "shift_by": 4,
+                                                                                                   "shift_by": 0,
                                                                                                      "suffix": "",
                                                                                                        "type": "integer"
                                                                                             } ],
@@ -1100,11 +1100,11 @@
                                                                                             } ],
                                                                      "momentary_positions": "none",
                                                                                  "outputs": [ {
-                                                                                                    "address": 4436,
+                                                                                                    "address": 4420,
                                                                                                 "description": "selector position",
-                                                                                                       "mask": 12,
+                                                                                                       "mask": 24576,
                                                                                                   "max_value": 2,
-                                                                                                   "shift_by": 2,
+                                                                                                   "shift_by": 13,
                                                                                                      "suffix": "",
                                                                                                        "type": "integer"
                                                                                             } ],
@@ -1126,7 +1126,7 @@
                                                                                          "suggested_step": 3200
                                                                                      } ],
                                                                           "outputs": [ {
-                                                                                             "address": 4442,
+                                                                                             "address": 4438,
                                                                                          "description": "position of the potentiometer",
                                                                                                 "mask": 65535,
                                                                                            "max_value": 65535,
@@ -1151,7 +1151,7 @@
                                                                                          "suggested_step": 3200
                                                                                      } ],
                                                                           "outputs": [ {
-                                                                                             "address": 4438,
+                                                                                             "address": 4434,
                                                                                          "description": "position of the potentiometer",
                                                                                                 "mask": 65535,
                                                                                            "max_value": 65535,
@@ -1176,7 +1176,7 @@
                                                                                          "suggested_step": 3200
                                                                                      } ],
                                                                           "outputs": [ {
-                                                                                             "address": 4440,
+                                                                                             "address": 4436,
                                                                                          "description": "position of the potentiometer",
                                                                                                 "mask": 65535,
                                                                                            "max_value": 65535,
@@ -1205,11 +1205,11 @@
                                                                                             } ],
                                                                      "momentary_positions": "none",
                                                                                  "outputs": [ {
-                                                                                                    "address": 4380,
+                                                                                                    "address": 4374,
                                                                                                 "description": "selector position",
-                                                                                                       "mask": 32768,
+                                                                                                       "mask": 16384,
                                                                                                   "max_value": 1,
-                                                                                                   "shift_by": 15,
+                                                                                                   "shift_by": 14,
                                                                                                      "suffix": "",
                                                                                                        "type": "integer"
                                                                                             } ],
@@ -1237,7 +1237,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4342,
+                                                                                                "address": 4340,
                                                                                             "description": "selector position",
                                                                                                    "mask": 4096,
                                                                                               "max_value": 1,
@@ -1267,7 +1267,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4342,
+                                                                                                "address": 4340,
                                                                                             "description": "selector position",
                                                                                                    "mask": 8,
                                                                                               "max_value": 1,
@@ -1297,7 +1297,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4342,
+                                                                                                "address": 4340,
                                                                                             "description": "selector position",
                                                                                                    "mask": 16,
                                                                                               "max_value": 1,
@@ -1327,7 +1327,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4342,
+                                                                                                "address": 4340,
                                                                                             "description": "selector position",
                                                                                                    "mask": 32,
                                                                                               "max_value": 1,
@@ -1357,7 +1357,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4342,
+                                                                                                "address": 4340,
                                                                                             "description": "selector position",
                                                                                                    "mask": 64,
                                                                                               "max_value": 1,
@@ -1387,7 +1387,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4342,
+                                                                                                "address": 4340,
                                                                                             "description": "selector position",
                                                                                                    "mask": 128,
                                                                                               "max_value": 1,
@@ -1417,7 +1417,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4342,
+                                                                                                "address": 4340,
                                                                                             "description": "selector position",
                                                                                                    "mask": 256,
                                                                                               "max_value": 1,
@@ -1447,7 +1447,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4342,
+                                                                                                "address": 4340,
                                                                                             "description": "selector position",
                                                                                                    "mask": 512,
                                                                                               "max_value": 1,
@@ -1477,7 +1477,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4342,
+                                                                                                "address": 4340,
                                                                                             "description": "selector position",
                                                                                                    "mask": 1024,
                                                                                               "max_value": 1,
@@ -1507,7 +1507,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4342,
+                                                                                                "address": 4340,
                                                                                             "description": "selector position",
                                                                                                    "mask": 2048,
                                                                                               "max_value": 1,
@@ -1537,7 +1537,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4342,
+                                                                                                "address": 4340,
                                                                                             "description": "selector position",
                                                                                                    "mask": 32768,
                                                                                               "max_value": 1,
@@ -1567,7 +1567,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4344,
+                                                                                                "address": 4342,
                                                                                             "description": "selector position",
                                                                                                    "mask": 1,
                                                                                               "max_value": 1,
@@ -1597,7 +1597,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4346,
+                                                                                                "address": 4344,
                                                                                             "description": "selector position",
                                                                                                    "mask": 4096,
                                                                                               "max_value": 1,
@@ -1619,7 +1619,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "first_and_last",
                                                                              "outputs": [ {
-                                                                                                "address": 4348,
+                                                                                                "address": 4346,
                                                                                             "description": "selector position",
                                                                                                    "mask": 3,
                                                                                               "max_value": 2,
@@ -1649,7 +1649,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4344,
+                                                                                                "address": 4342,
                                                                                             "description": "selector position",
                                                                                                    "mask": 2,
                                                                                               "max_value": 1,
@@ -1679,7 +1679,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4346,
+                                                                                                "address": 4344,
                                                                                             "description": "selector position",
                                                                                                    "mask": 16384,
                                                                                               "max_value": 1,
@@ -1709,7 +1709,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4344,
+                                                                                                "address": 4342,
                                                                                             "description": "selector position",
                                                                                                    "mask": 4,
                                                                                               "max_value": 1,
@@ -1731,7 +1731,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "first_and_last",
                                                                              "outputs": [ {
-                                                                                                "address": 4348,
+                                                                                                "address": 4346,
                                                                                             "description": "selector position",
                                                                                                    "mask": 192,
                                                                                               "max_value": 2,
@@ -1761,7 +1761,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4344,
+                                                                                                "address": 4342,
                                                                                             "description": "selector position",
                                                                                                    "mask": 8,
                                                                                               "max_value": 1,
@@ -1791,7 +1791,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4344,
+                                                                                                "address": 4342,
                                                                                             "description": "selector position",
                                                                                                    "mask": 16,
                                                                                               "max_value": 1,
@@ -1821,7 +1821,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4346,
+                                                                                                "address": 4344,
                                                                                             "description": "selector position",
                                                                                                    "mask": 32768,
                                                                                               "max_value": 1,
@@ -1851,7 +1851,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4342,
+                                                                                                "address": 4340,
                                                                                             "description": "selector position",
                                                                                                    "mask": 2,
                                                                                               "max_value": 1,
@@ -1881,7 +1881,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4344,
+                                                                                                "address": 4342,
                                                                                             "description": "selector position",
                                                                                                    "mask": 32,
                                                                                               "max_value": 1,
@@ -1911,7 +1911,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4344,
+                                                                                                "address": 4342,
                                                                                             "description": "selector position",
                                                                                                    "mask": 64,
                                                                                               "max_value": 1,
@@ -1941,7 +1941,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4344,
+                                                                                                "address": 4342,
                                                                                             "description": "selector position",
                                                                                                    "mask": 128,
                                                                                               "max_value": 1,
@@ -1971,7 +1971,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4344,
+                                                                                                "address": 4342,
                                                                                             "description": "selector position",
                                                                                                    "mask": 256,
                                                                                               "max_value": 1,
@@ -2001,7 +2001,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4344,
+                                                                                                "address": 4342,
                                                                                             "description": "selector position",
                                                                                                    "mask": 512,
                                                                                               "max_value": 1,
@@ -2031,7 +2031,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4344,
+                                                                                                "address": 4342,
                                                                                             "description": "selector position",
                                                                                                    "mask": 1024,
                                                                                               "max_value": 1,
@@ -2061,7 +2061,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4340,
+                                                                                                "address": 4338,
                                                                                             "description": "selector position",
                                                                                                    "mask": 32,
                                                                                               "max_value": 1,
@@ -2091,7 +2091,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4340,
+                                                                                                "address": 4338,
                                                                                             "description": "selector position",
                                                                                                    "mask": 512,
                                                                                               "max_value": 1,
@@ -2121,7 +2121,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4340,
+                                                                                                "address": 4338,
                                                                                             "description": "selector position",
                                                                                                    "mask": 64,
                                                                                               "max_value": 1,
@@ -2151,7 +2151,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4340,
+                                                                                                "address": 4338,
                                                                                             "description": "selector position",
                                                                                                    "mask": 1024,
                                                                                               "max_value": 1,
@@ -2181,7 +2181,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4340,
+                                                                                                "address": 4338,
                                                                                             "description": "selector position",
                                                                                                    "mask": 128,
                                                                                               "max_value": 1,
@@ -2211,7 +2211,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4340,
+                                                                                                "address": 4338,
                                                                                             "description": "selector position",
                                                                                                    "mask": 2048,
                                                                                               "max_value": 1,
@@ -2241,7 +2241,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4340,
+                                                                                                "address": 4338,
                                                                                             "description": "selector position",
                                                                                                    "mask": 256,
                                                                                               "max_value": 1,
@@ -2271,7 +2271,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4340,
+                                                                                                "address": 4338,
                                                                                             "description": "selector position",
                                                                                                    "mask": 4096,
                                                                                               "max_value": 1,
@@ -2301,7 +2301,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4344,
+                                                                                                "address": 4342,
                                                                                             "description": "selector position",
                                                                                                    "mask": 2048,
                                                                                               "max_value": 1,
@@ -2331,7 +2331,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4346,
+                                                                                                "address": 4344,
                                                                                             "description": "selector position",
                                                                                                    "mask": 2048,
                                                                                               "max_value": 1,
@@ -2361,7 +2361,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4344,
+                                                                                                "address": 4342,
                                                                                             "description": "selector position",
                                                                                                    "mask": 4096,
                                                                                               "max_value": 1,
@@ -2391,7 +2391,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4346,
+                                                                                                "address": 4344,
                                                                                             "description": "selector position",
                                                                                                    "mask": 512,
                                                                                               "max_value": 1,
@@ -2421,7 +2421,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4346,
+                                                                                                "address": 4344,
                                                                                             "description": "selector position",
                                                                                                    "mask": 1024,
                                                                                               "max_value": 1,
@@ -2451,7 +2451,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4340,
+                                                                                                "address": 4338,
                                                                                             "description": "selector position",
                                                                                                    "mask": 16384,
                                                                                               "max_value": 1,
@@ -2481,7 +2481,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4344,
+                                                                                                "address": 4342,
                                                                                             "description": "selector position",
                                                                                                    "mask": 8192,
                                                                                               "max_value": 1,
@@ -2511,7 +2511,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4342,
+                                                                                                "address": 4340,
                                                                                             "description": "selector position",
                                                                                                    "mask": 1,
                                                                                               "max_value": 1,
@@ -2541,7 +2541,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4344,
+                                                                                                "address": 4342,
                                                                                             "description": "selector position",
                                                                                                    "mask": 16384,
                                                                                               "max_value": 1,
@@ -2563,7 +2563,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "first_and_last",
                                                                              "outputs": [ {
-                                                                                                "address": 4348,
+                                                                                                "address": 4346,
                                                                                             "description": "selector position",
                                                                                                    "mask": 12,
                                                                                               "max_value": 2,
@@ -2593,7 +2593,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4342,
+                                                                                                "address": 4340,
                                                                                             "description": "selector position",
                                                                                                    "mask": 8192,
                                                                                               "max_value": 1,
@@ -2623,7 +2623,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4342,
+                                                                                                "address": 4340,
                                                                                             "description": "selector position",
                                                                                                    "mask": 4,
                                                                                               "max_value": 1,
@@ -2653,7 +2653,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4344,
+                                                                                                "address": 4342,
                                                                                             "description": "selector position",
                                                                                                    "mask": 32768,
                                                                                               "max_value": 1,
@@ -2683,7 +2683,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4346,
+                                                                                                "address": 4344,
                                                                                             "description": "selector position",
                                                                                                    "mask": 1,
                                                                                               "max_value": 1,
@@ -2713,7 +2713,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4346,
+                                                                                                "address": 4344,
                                                                                             "description": "selector position",
                                                                                                    "mask": 2,
                                                                                               "max_value": 1,
@@ -2735,7 +2735,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "first_and_last",
                                                                              "outputs": [ {
-                                                                                                "address": 4348,
+                                                                                                "address": 4346,
                                                                                             "description": "selector position",
                                                                                                    "mask": 48,
                                                                                               "max_value": 2,
@@ -2765,7 +2765,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4342,
+                                                                                                "address": 4340,
                                                                                             "description": "selector position",
                                                                                                    "mask": 16384,
                                                                                               "max_value": 1,
@@ -2795,7 +2795,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4346,
+                                                                                                "address": 4344,
                                                                                             "description": "selector position",
                                                                                                    "mask": 8192,
                                                                                               "max_value": 1,
@@ -2825,7 +2825,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4340,
+                                                                                                "address": 4338,
                                                                                             "description": "selector position",
                                                                                                    "mask": 8192,
                                                                                               "max_value": 1,
@@ -2855,7 +2855,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4346,
+                                                                                                "address": 4344,
                                                                                             "description": "selector position",
                                                                                                    "mask": 4,
                                                                                               "max_value": 1,
@@ -2885,7 +2885,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4346,
+                                                                                                "address": 4344,
                                                                                             "description": "selector position",
                                                                                                    "mask": 8,
                                                                                               "max_value": 1,
@@ -2915,7 +2915,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4346,
+                                                                                                "address": 4344,
                                                                                             "description": "selector position",
                                                                                                    "mask": 16,
                                                                                               "max_value": 1,
@@ -2945,7 +2945,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4346,
+                                                                                                "address": 4344,
                                                                                             "description": "selector position",
                                                                                                    "mask": 32,
                                                                                               "max_value": 1,
@@ -2975,7 +2975,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4340,
+                                                                                                "address": 4338,
                                                                                             "description": "selector position",
                                                                                                    "mask": 32768,
                                                                                               "max_value": 1,
@@ -3005,7 +3005,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4346,
+                                                                                                "address": 4344,
                                                                                             "description": "selector position",
                                                                                                    "mask": 64,
                                                                                               "max_value": 1,
@@ -3035,7 +3035,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4346,
+                                                                                                "address": 4344,
                                                                                             "description": "selector position",
                                                                                                    "mask": 128,
                                                                                               "max_value": 1,
@@ -3065,7 +3065,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4346,
+                                                                                                "address": 4344,
                                                                                             "description": "selector position",
                                                                                                    "mask": 256,
                                                                                               "max_value": 1,
@@ -3084,7 +3084,7 @@
                                                                   "identifier": "CDU_LINE0",
                                                                       "inputs": [  ],
                                                                      "outputs": [ {
-                                                                                        "address": 4546,
+                                                                                        "address": 4544,
                                                                                     "description": "CDU Line 1",
                                                                                      "max_length": 24,
                                                                                          "suffix": "",
@@ -3098,7 +3098,7 @@
                                                                   "identifier": "CDU_LINE1",
                                                                       "inputs": [  ],
                                                                      "outputs": [ {
-                                                                                        "address": 4570,
+                                                                                        "address": 4568,
                                                                                     "description": "CDU Line 2",
                                                                                      "max_length": 24,
                                                                                          "suffix": "",
@@ -3112,7 +3112,7 @@
                                                                   "identifier": "CDU_LINE2",
                                                                       "inputs": [  ],
                                                                      "outputs": [ {
-                                                                                        "address": 4594,
+                                                                                        "address": 4592,
                                                                                     "description": "CDU Line 3",
                                                                                      "max_length": 24,
                                                                                          "suffix": "",
@@ -3126,7 +3126,7 @@
                                                                   "identifier": "CDU_LINE3",
                                                                       "inputs": [  ],
                                                                      "outputs": [ {
-                                                                                        "address": 4618,
+                                                                                        "address": 4616,
                                                                                     "description": "CDU Line 4",
                                                                                      "max_length": 24,
                                                                                          "suffix": "",
@@ -3140,7 +3140,7 @@
                                                                   "identifier": "CDU_LINE4",
                                                                       "inputs": [  ],
                                                                      "outputs": [ {
-                                                                                        "address": 4642,
+                                                                                        "address": 4640,
                                                                                     "description": "CDU Line 5",
                                                                                      "max_length": 24,
                                                                                          "suffix": "",
@@ -3154,7 +3154,7 @@
                                                                   "identifier": "CDU_LINE5",
                                                                       "inputs": [  ],
                                                                      "outputs": [ {
-                                                                                        "address": 4666,
+                                                                                        "address": 4664,
                                                                                     "description": "CDU Line 6",
                                                                                      "max_length": 24,
                                                                                          "suffix": "",
@@ -3168,7 +3168,7 @@
                                                                   "identifier": "CDU_LINE6",
                                                                       "inputs": [  ],
                                                                      "outputs": [ {
-                                                                                        "address": 4690,
+                                                                                        "address": 4688,
                                                                                     "description": "CDU Line 7",
                                                                                      "max_length": 24,
                                                                                          "suffix": "",
@@ -3182,7 +3182,7 @@
                                                                   "identifier": "CDU_LINE7",
                                                                       "inputs": [  ],
                                                                      "outputs": [ {
-                                                                                        "address": 4714,
+                                                                                        "address": 4712,
                                                                                     "description": "CDU Line 8",
                                                                                      "max_length": 24,
                                                                                          "suffix": "",
@@ -3196,7 +3196,7 @@
                                                                   "identifier": "CDU_LINE8",
                                                                       "inputs": [  ],
                                                                      "outputs": [ {
-                                                                                        "address": 4738,
+                                                                                        "address": 4736,
                                                                                     "description": "CDU Line 9",
                                                                                      "max_length": 24,
                                                                                          "suffix": "",
@@ -3210,7 +3210,7 @@
                                                                   "identifier": "CDU_LINE9",
                                                                       "inputs": [  ],
                                                                      "outputs": [ {
-                                                                                        "address": 4762,
+                                                                                        "address": 4760,
                                                                                     "description": "CDU Line 10",
                                                                                      "max_length": 24,
                                                                                          "suffix": "",
@@ -3235,7 +3235,7 @@
                                                                                                "suggested_step": 3200
                                                                                            } ],
                                                                                 "outputs": [ {
-                                                                                                   "address": 4332,
+                                                                                                   "address": 4330,
                                                                                                "description": "position of the potentiometer",
                                                                                                       "mask": 65535,
                                                                                                  "max_value": 65535,
@@ -3264,7 +3264,7 @@
                                                                                                   } ],
                                                                            "momentary_positions": "none",
                                                                                        "outputs": [ {
-                                                                                                          "address": 4326,
+                                                                                                          "address": 4324,
                                                                                                       "description": "selector position",
                                                                                                              "mask": 16384,
                                                                                                         "max_value": 1,
@@ -3310,7 +3310,7 @@
                                                                                                   } ],
                                                                            "momentary_positions": "none",
                                                                                        "outputs": [ {
-                                                                                                          "address": 4326,
+                                                                                                          "address": 4324,
                                                                                                       "description": "selector position",
                                                                                                              "mask": 32768,
                                                                                                         "max_value": 1,
@@ -3340,7 +3340,7 @@
                                                                                                   } ],
                                                                            "momentary_positions": "none",
                                                                                        "outputs": [ {
-                                                                                                          "address": 4330,
+                                                                                                          "address": 4328,
                                                                                                       "description": "selector position",
                                                                                                              "mask": 1,
                                                                                                         "max_value": 1,
@@ -3382,7 +3382,7 @@
                                                                                                "suggested_step": 3200
                                                                                            } ],
                                                                                 "outputs": [ {
-                                                                                                   "address": 4334,
+                                                                                                   "address": 4332,
                                                                                                "description": "position of the potentiometer",
                                                                                                       "mask": 65535,
                                                                                                  "max_value": 65535,
@@ -3411,7 +3411,7 @@
                                                                                                   } ],
                                                                            "momentary_positions": "none",
                                                                                        "outputs": [ {
-                                                                                                          "address": 4330,
+                                                                                                          "address": 4328,
                                                                                                       "description": "selector position",
                                                                                                              "mask": 2,
                                                                                                         "max_value": 1,
@@ -3456,7 +3456,7 @@
                                                                              "identifier": "CMSC_TXT_MWS",
                                                                                  "inputs": [  ],
                                                                                 "outputs": [ {
-                                                                                                   "address": 4786,
+                                                                                                   "address": 4784,
                                                                                                "description": "MWS Status Display",
                                                                                                 "max_length": 8,
                                                                                                     "suffix": "",
@@ -3529,7 +3529,7 @@
                                                                                        } ],
                                                                 "momentary_positions": "none",
                                                                             "outputs": [ {
-                                                                                               "address": 4322,
+                                                                                               "address": 4320,
                                                                                            "description": "selector position",
                                                                                                   "mask": 32768,
                                                                                              "max_value": 1,
@@ -3559,7 +3559,7 @@
                                                                                        } ],
                                                                 "momentary_positions": "none",
                                                                             "outputs": [ {
-                                                                                               "address": 4324,
+                                                                                               "address": 4322,
                                                                                            "description": "selector position",
                                                                                                   "mask": 4096,
                                                                                              "max_value": 1,
@@ -3589,7 +3589,7 @@
                                                                                        } ],
                                                                 "momentary_positions": "none",
                                                                             "outputs": [ {
-                                                                                               "address": 4324,
+                                                                                               "address": 4322,
                                                                                            "description": "selector position",
                                                                                                   "mask": 8192,
                                                                                              "max_value": 1,
@@ -3619,7 +3619,7 @@
                                                                                        } ],
                                                                 "momentary_positions": "none",
                                                                             "outputs": [ {
-                                                                                               "address": 4324,
+                                                                                               "address": 4322,
                                                                                            "description": "selector position",
                                                                                                   "mask": 16384,
                                                                                              "max_value": 1,
@@ -3645,7 +3645,7 @@
                                                                                     "suggested_step": 3200
                                                                                 } ],
                                                                      "outputs": [ {
-                                                                                        "address": 4328,
+                                                                                        "address": 4326,
                                                                                     "description": "position of the potentiometer",
                                                                                            "mask": 65535,
                                                                                       "max_value": 65535,
@@ -3666,7 +3666,7 @@
                                                                                        } ],
                                                                 "momentary_positions": "last",
                                                                             "outputs": [ {
-                                                                                               "address": 4326,
+                                                                                               "address": 4324,
                                                                                            "description": "switch position: 0 - down, 1 - center, 2 - up",
                                                                                                   "mask": 1536,
                                                                                              "max_value": 2,
@@ -3688,7 +3688,7 @@
                                                                                        } ],
                                                                 "momentary_positions": "last",
                                                                             "outputs": [ {
-                                                                                               "address": 4326,
+                                                                                               "address": 4324,
                                                                                            "description": "switch position: 0 - down, 1 - center, 2 - up",
                                                                                                   "mask": 96,
                                                                                              "max_value": 2,
@@ -3717,7 +3717,7 @@
                                                                                        } ],
                                                                 "momentary_positions": "none",
                                                                             "outputs": [ {
-                                                                                               "address": 4326,
+                                                                                               "address": 4324,
                                                                                            "description": "selector position",
                                                                                                   "mask": 4,
                                                                                              "max_value": 1,
@@ -3742,7 +3742,7 @@
                                                                                        } ],
                                                                 "momentary_positions": "none",
                                                                             "outputs": [ {
-                                                                                               "address": 4326,
+                                                                                               "address": 4324,
                                                                                            "description": "selector position",
                                                                                                   "mask": 14336,
                                                                                              "max_value": 4,
@@ -3764,7 +3764,7 @@
                                                                                        } ],
                                                                 "momentary_positions": "last",
                                                                             "outputs": [ {
-                                                                                               "address": 4326,
+                                                                                               "address": 4324,
                                                                                            "description": "switch position: 0 - down, 1 - center, 2 - up",
                                                                                                   "mask": 24,
                                                                                              "max_value": 2,
@@ -3794,7 +3794,7 @@
                                                                                        } ],
                                                                 "momentary_positions": "none",
                                                                             "outputs": [ {
-                                                                                               "address": 4324,
+                                                                                               "address": 4322,
                                                                                            "description": "selector position",
                                                                                                   "mask": 32768,
                                                                                              "max_value": 1,
@@ -3816,7 +3816,7 @@
                                                                                        } ],
                                                                 "momentary_positions": "last",
                                                                             "outputs": [ {
-                                                                                               "address": 4326,
+                                                                                               "address": 4324,
                                                                                            "description": "switch position: 0 - down, 1 - center, 2 - up",
                                                                                                   "mask": 384,
                                                                                              "max_value": 2,
@@ -3838,7 +3838,7 @@
                                                                                        } ],
                                                                 "momentary_positions": "first_and_last",
                                                                             "outputs": [ {
-                                                                                               "address": 4326,
+                                                                                               "address": 4324,
                                                                                            "description": "selector position",
                                                                                                   "mask": 3,
                                                                                              "max_value": 2,
@@ -3857,7 +3857,7 @@
                                                               "identifier": "CL_A1",
                                                                   "inputs": [  ],
                                                                  "outputs": [ {
-                                                                                    "address": 4310,
+                                                                                    "address": 4308,
                                                                                 "description": "0 if light is off, 1 if light is on",
                                                                                        "mask": 1,
                                                                                   "max_value": 1,
@@ -3873,7 +3873,7 @@
                                                               "identifier": "CL_A2",
                                                                   "inputs": [  ],
                                                                  "outputs": [ {
-                                                                                    "address": 4310,
+                                                                                    "address": 4308,
                                                                                 "description": "0 if light is off, 1 if light is on",
                                                                                        "mask": 2,
                                                                                   "max_value": 1,
@@ -3889,7 +3889,7 @@
                                                               "identifier": "CL_A3",
                                                                   "inputs": [  ],
                                                                  "outputs": [ {
-                                                                                    "address": 4310,
+                                                                                    "address": 4308,
                                                                                 "description": "0 if light is off, 1 if light is on",
                                                                                        "mask": 4,
                                                                                   "max_value": 1,
@@ -3905,7 +3905,7 @@
                                                               "identifier": "CL_A4",
                                                                   "inputs": [  ],
                                                                  "outputs": [ {
-                                                                                    "address": 4310,
+                                                                                    "address": 4308,
                                                                                 "description": "0 if light is off, 1 if light is on",
                                                                                        "mask": 8,
                                                                                   "max_value": 1,
@@ -3921,7 +3921,7 @@
                                                               "identifier": "CL_B1",
                                                                   "inputs": [  ],
                                                                  "outputs": [ {
-                                                                                    "address": 4310,
+                                                                                    "address": 4308,
                                                                                 "description": "0 if light is off, 1 if light is on",
                                                                                        "mask": 16,
                                                                                   "max_value": 1,
@@ -3937,7 +3937,7 @@
                                                               "identifier": "CL_B2",
                                                                   "inputs": [  ],
                                                                  "outputs": [ {
-                                                                                    "address": 4310,
+                                                                                    "address": 4308,
                                                                                 "description": "0 if light is off, 1 if light is on",
                                                                                        "mask": 32,
                                                                                   "max_value": 1,
@@ -3953,7 +3953,7 @@
                                                               "identifier": "CL_B3",
                                                                   "inputs": [  ],
                                                                  "outputs": [ {
-                                                                                    "address": 4310,
+                                                                                    "address": 4308,
                                                                                 "description": "0 if light is off, 1 if light is on",
                                                                                        "mask": 64,
                                                                                   "max_value": 1,
@@ -3969,7 +3969,7 @@
                                                               "identifier": "CL_B4",
                                                                   "inputs": [  ],
                                                                  "outputs": [ {
-                                                                                    "address": 4310,
+                                                                                    "address": 4308,
                                                                                 "description": "0 if light is off, 1 if light is on",
                                                                                        "mask": 128,
                                                                                   "max_value": 1,
@@ -3985,7 +3985,7 @@
                                                               "identifier": "CL_C1",
                                                                   "inputs": [  ],
                                                                  "outputs": [ {
-                                                                                    "address": 4310,
+                                                                                    "address": 4308,
                                                                                 "description": "0 if light is off, 1 if light is on",
                                                                                        "mask": 256,
                                                                                   "max_value": 1,
@@ -4001,7 +4001,7 @@
                                                               "identifier": "CL_C2",
                                                                   "inputs": [  ],
                                                                  "outputs": [ {
-                                                                                    "address": 4310,
+                                                                                    "address": 4308,
                                                                                 "description": "0 if light is off, 1 if light is on",
                                                                                        "mask": 512,
                                                                                   "max_value": 1,
@@ -4017,7 +4017,7 @@
                                                               "identifier": "CL_C3",
                                                                   "inputs": [  ],
                                                                  "outputs": [ {
-                                                                                    "address": 4310,
+                                                                                    "address": 4308,
                                                                                 "description": "0 if light is off, 1 if light is on",
                                                                                        "mask": 1024,
                                                                                   "max_value": 1,
@@ -4033,7 +4033,7 @@
                                                               "identifier": "CL_C4",
                                                                   "inputs": [  ],
                                                                  "outputs": [ {
-                                                                                    "address": 4310,
+                                                                                    "address": 4308,
                                                                                 "description": "0 if light is off, 1 if light is on",
                                                                                        "mask": 2048,
                                                                                   "max_value": 1,
@@ -4049,7 +4049,7 @@
                                                               "identifier": "CL_D1",
                                                                   "inputs": [  ],
                                                                  "outputs": [ {
-                                                                                    "address": 4310,
+                                                                                    "address": 4308,
                                                                                 "description": "0 if light is off, 1 if light is on",
                                                                                        "mask": 4096,
                                                                                   "max_value": 1,
@@ -4065,7 +4065,7 @@
                                                               "identifier": "CL_D2",
                                                                   "inputs": [  ],
                                                                  "outputs": [ {
-                                                                                    "address": 4310,
+                                                                                    "address": 4308,
                                                                                 "description": "0 if light is off, 1 if light is on",
                                                                                        "mask": 8192,
                                                                                   "max_value": 1,
@@ -4081,7 +4081,7 @@
                                                               "identifier": "CL_D3",
                                                                   "inputs": [  ],
                                                                  "outputs": [ {
-                                                                                    "address": 4310,
+                                                                                    "address": 4308,
                                                                                 "description": "0 if light is off, 1 if light is on",
                                                                                        "mask": 16384,
                                                                                   "max_value": 1,
@@ -4097,7 +4097,7 @@
                                                               "identifier": "CL_D4",
                                                                   "inputs": [  ],
                                                                  "outputs": [ {
-                                                                                    "address": 4310,
+                                                                                    "address": 4308,
                                                                                 "description": "0 if light is off, 1 if light is on",
                                                                                        "mask": 32768,
                                                                                   "max_value": 1,
@@ -4113,7 +4113,7 @@
                                                               "identifier": "CL_E1",
                                                                   "inputs": [  ],
                                                                  "outputs": [ {
-                                                                                    "address": 4312,
+                                                                                    "address": 4310,
                                                                                 "description": "0 if light is off, 1 if light is on",
                                                                                        "mask": 1,
                                                                                   "max_value": 1,
@@ -4129,7 +4129,7 @@
                                                               "identifier": "CL_E2",
                                                                   "inputs": [  ],
                                                                  "outputs": [ {
-                                                                                    "address": 4312,
+                                                                                    "address": 4310,
                                                                                 "description": "0 if light is off, 1 if light is on",
                                                                                        "mask": 2,
                                                                                   "max_value": 1,
@@ -4145,7 +4145,7 @@
                                                               "identifier": "CL_E3",
                                                                   "inputs": [  ],
                                                                  "outputs": [ {
-                                                                                    "address": 4312,
+                                                                                    "address": 4310,
                                                                                 "description": "0 if light is off, 1 if light is on",
                                                                                        "mask": 4,
                                                                                   "max_value": 1,
@@ -4161,7 +4161,7 @@
                                                               "identifier": "CL_E4",
                                                                   "inputs": [  ],
                                                                  "outputs": [ {
-                                                                                    "address": 4312,
+                                                                                    "address": 4310,
                                                                                 "description": "0 if light is off, 1 if light is on",
                                                                                        "mask": 8,
                                                                                   "max_value": 1,
@@ -4177,7 +4177,7 @@
                                                               "identifier": "CL_F1",
                                                                   "inputs": [  ],
                                                                  "outputs": [ {
-                                                                                    "address": 4312,
+                                                                                    "address": 4310,
                                                                                 "description": "0 if light is off, 1 if light is on",
                                                                                        "mask": 16,
                                                                                   "max_value": 1,
@@ -4193,7 +4193,7 @@
                                                               "identifier": "CL_F2",
                                                                   "inputs": [  ],
                                                                  "outputs": [ {
-                                                                                    "address": 4312,
+                                                                                    "address": 4310,
                                                                                 "description": "0 if light is off, 1 if light is on",
                                                                                        "mask": 32,
                                                                                   "max_value": 1,
@@ -4209,7 +4209,7 @@
                                                               "identifier": "CL_F3",
                                                                   "inputs": [  ],
                                                                  "outputs": [ {
-                                                                                    "address": 4312,
+                                                                                    "address": 4310,
                                                                                 "description": "0 if light is off, 1 if light is on",
                                                                                        "mask": 64,
                                                                                   "max_value": 1,
@@ -4225,7 +4225,7 @@
                                                               "identifier": "CL_F4",
                                                                   "inputs": [  ],
                                                                  "outputs": [ {
-                                                                                    "address": 4312,
+                                                                                    "address": 4310,
                                                                                 "description": "0 if light is off, 1 if light is on",
                                                                                        "mask": 128,
                                                                                   "max_value": 1,
@@ -4241,7 +4241,7 @@
                                                               "identifier": "CL_G1",
                                                                   "inputs": [  ],
                                                                  "outputs": [ {
-                                                                                    "address": 4312,
+                                                                                    "address": 4310,
                                                                                 "description": "0 if light is off, 1 if light is on",
                                                                                        "mask": 256,
                                                                                   "max_value": 1,
@@ -4257,7 +4257,7 @@
                                                               "identifier": "CL_G2",
                                                                   "inputs": [  ],
                                                                  "outputs": [ {
-                                                                                    "address": 4312,
+                                                                                    "address": 4310,
                                                                                 "description": "0 if light is off, 1 if light is on",
                                                                                        "mask": 512,
                                                                                   "max_value": 1,
@@ -4273,7 +4273,7 @@
                                                               "identifier": "CL_G3",
                                                                   "inputs": [  ],
                                                                  "outputs": [ {
-                                                                                    "address": 4312,
+                                                                                    "address": 4310,
                                                                                 "description": "0 if light is off, 1 if light is on",
                                                                                        "mask": 1024,
                                                                                   "max_value": 1,
@@ -4289,7 +4289,7 @@
                                                               "identifier": "CL_G4",
                                                                   "inputs": [  ],
                                                                  "outputs": [ {
-                                                                                    "address": 4312,
+                                                                                    "address": 4310,
                                                                                 "description": "0 if light is off, 1 if light is on",
                                                                                        "mask": 2048,
                                                                                   "max_value": 1,
@@ -4305,7 +4305,7 @@
                                                               "identifier": "CL_H1",
                                                                   "inputs": [  ],
                                                                  "outputs": [ {
-                                                                                    "address": 4312,
+                                                                                    "address": 4310,
                                                                                 "description": "0 if light is off, 1 if light is on",
                                                                                        "mask": 4096,
                                                                                   "max_value": 1,
@@ -4321,7 +4321,7 @@
                                                               "identifier": "CL_H2",
                                                                   "inputs": [  ],
                                                                  "outputs": [ {
-                                                                                    "address": 4312,
+                                                                                    "address": 4310,
                                                                                 "description": "0 if light is off, 1 if light is on",
                                                                                        "mask": 8192,
                                                                                   "max_value": 1,
@@ -4337,7 +4337,7 @@
                                                               "identifier": "CL_H3",
                                                                   "inputs": [  ],
                                                                  "outputs": [ {
-                                                                                    "address": 4312,
+                                                                                    "address": 4310,
                                                                                 "description": "0 if light is off, 1 if light is on",
                                                                                        "mask": 16384,
                                                                                   "max_value": 1,
@@ -4353,7 +4353,7 @@
                                                               "identifier": "CL_H4",
                                                                   "inputs": [  ],
                                                                  "outputs": [ {
-                                                                                    "address": 4312,
+                                                                                    "address": 4310,
                                                                                 "description": "0 if light is off, 1 if light is on",
                                                                                        "mask": 32768,
                                                                                   "max_value": 1,
@@ -4369,7 +4369,7 @@
                                                               "identifier": "CL_I1",
                                                                   "inputs": [  ],
                                                                  "outputs": [ {
-                                                                                    "address": 4314,
+                                                                                    "address": 4312,
                                                                                 "description": "0 if light is off, 1 if light is on",
                                                                                        "mask": 1,
                                                                                   "max_value": 1,
@@ -4385,7 +4385,7 @@
                                                               "identifier": "CL_I2",
                                                                   "inputs": [  ],
                                                                  "outputs": [ {
-                                                                                    "address": 4314,
+                                                                                    "address": 4312,
                                                                                 "description": "0 if light is off, 1 if light is on",
                                                                                        "mask": 2,
                                                                                   "max_value": 1,
@@ -4401,7 +4401,7 @@
                                                               "identifier": "CL_I3",
                                                                   "inputs": [  ],
                                                                  "outputs": [ {
-                                                                                    "address": 4314,
+                                                                                    "address": 4312,
                                                                                 "description": "0 if light is off, 1 if light is on",
                                                                                        "mask": 4,
                                                                                   "max_value": 1,
@@ -4417,7 +4417,7 @@
                                                               "identifier": "CL_I4",
                                                                   "inputs": [  ],
                                                                  "outputs": [ {
-                                                                                    "address": 4314,
+                                                                                    "address": 4312,
                                                                                 "description": "0 if light is off, 1 if light is on",
                                                                                        "mask": 8,
                                                                                   "max_value": 1,
@@ -4433,7 +4433,7 @@
                                                               "identifier": "CL_J1",
                                                                   "inputs": [  ],
                                                                  "outputs": [ {
-                                                                                    "address": 4314,
+                                                                                    "address": 4312,
                                                                                 "description": "0 if light is off, 1 if light is on",
                                                                                        "mask": 16,
                                                                                   "max_value": 1,
@@ -4449,7 +4449,7 @@
                                                               "identifier": "CL_J2",
                                                                   "inputs": [  ],
                                                                  "outputs": [ {
-                                                                                    "address": 4314,
+                                                                                    "address": 4312,
                                                                                 "description": "0 if light is off, 1 if light is on",
                                                                                        "mask": 32,
                                                                                   "max_value": 1,
@@ -4465,7 +4465,7 @@
                                                               "identifier": "CL_J3",
                                                                   "inputs": [  ],
                                                                  "outputs": [ {
-                                                                                    "address": 4314,
+                                                                                    "address": 4312,
                                                                                 "description": "0 if light is off, 1 if light is on",
                                                                                        "mask": 64,
                                                                                   "max_value": 1,
@@ -4481,7 +4481,7 @@
                                                               "identifier": "CL_J4",
                                                                   "inputs": [  ],
                                                                  "outputs": [ {
-                                                                                    "address": 4314,
+                                                                                    "address": 4312,
                                                                                 "description": "0 if light is off, 1 if light is on",
                                                                                        "mask": 128,
                                                                                   "max_value": 1,
@@ -4497,7 +4497,7 @@
                                                               "identifier": "CL_K1",
                                                                   "inputs": [  ],
                                                                  "outputs": [ {
-                                                                                    "address": 4314,
+                                                                                    "address": 4312,
                                                                                 "description": "0 if light is off, 1 if light is on",
                                                                                        "mask": 256,
                                                                                   "max_value": 1,
@@ -4513,7 +4513,7 @@
                                                               "identifier": "CL_K2",
                                                                   "inputs": [  ],
                                                                  "outputs": [ {
-                                                                                    "address": 4314,
+                                                                                    "address": 4312,
                                                                                 "description": "0 if light is off, 1 if light is on",
                                                                                        "mask": 512,
                                                                                   "max_value": 1,
@@ -4529,7 +4529,7 @@
                                                               "identifier": "CL_K3",
                                                                   "inputs": [  ],
                                                                  "outputs": [ {
-                                                                                    "address": 4314,
+                                                                                    "address": 4312,
                                                                                 "description": "0 if light is off, 1 if light is on",
                                                                                        "mask": 1024,
                                                                                   "max_value": 1,
@@ -4545,7 +4545,7 @@
                                                               "identifier": "CL_K4",
                                                                   "inputs": [  ],
                                                                  "outputs": [ {
-                                                                                    "address": 4314,
+                                                                                    "address": 4312,
                                                                                 "description": "0 if light is off, 1 if light is on",
                                                                                        "mask": 2048,
                                                                                   "max_value": 1,
@@ -4561,7 +4561,7 @@
                                                               "identifier": "CL_L1",
                                                                   "inputs": [  ],
                                                                  "outputs": [ {
-                                                                                    "address": 4314,
+                                                                                    "address": 4312,
                                                                                 "description": "0 if light is off, 1 if light is on",
                                                                                        "mask": 4096,
                                                                                   "max_value": 1,
@@ -4577,7 +4577,7 @@
                                                               "identifier": "CL_L2",
                                                                   "inputs": [  ],
                                                                  "outputs": [ {
-                                                                                    "address": 4314,
+                                                                                    "address": 4312,
                                                                                 "description": "0 if light is off, 1 if light is on",
                                                                                        "mask": 8192,
                                                                                   "max_value": 1,
@@ -4593,7 +4593,7 @@
                                                               "identifier": "CL_L3",
                                                                   "inputs": [  ],
                                                                  "outputs": [ {
-                                                                                    "address": 4314,
+                                                                                    "address": 4312,
                                                                                 "description": "0 if light is off, 1 if light is on",
                                                                                        "mask": 16384,
                                                                                   "max_value": 1,
@@ -4609,7 +4609,7 @@
                                                               "identifier": "CL_L4",
                                                                   "inputs": [  ],
                                                                  "outputs": [ {
-                                                                                    "address": 4314,
+                                                                                    "address": 4312,
                                                                                 "description": "0 if light is off, 1 if light is on",
                                                                                        "mask": 32768,
                                                                                   "max_value": 1,
@@ -4642,9 +4642,9 @@
                                                                                           "outputs": [ {
                                                                                                              "address": 4408,
                                                                                                          "description": "selector position",
-                                                                                                                "mask": 16384,
+                                                                                                                "mask": 1024,
                                                                                                            "max_value": 1,
-                                                                                                            "shift_by": 14,
+                                                                                                            "shift_by": 10,
                                                                                                               "suffix": "",
                                                                                                                 "type": "integer"
                                                                                                      } ],
@@ -4672,9 +4672,9 @@
                                                                                           "outputs": [ {
                                                                                                              "address": 4408,
                                                                                                          "description": "selector position",
-                                                                                                                "mask": 32768,
+                                                                                                                "mask": 2048,
                                                                                                            "max_value": 1,
-                                                                                                            "shift_by": 15,
+                                                                                                            "shift_by": 11,
                                                                                                               "suffix": "",
                                                                                                                 "type": "integer"
                                                                                                      } ],
@@ -4700,11 +4700,11 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 4416,
+                                                                                                             "address": 4408,
                                                                                                          "description": "selector position",
-                                                                                                                "mask": 8,
+                                                                                                                "mask": 32768,
                                                                                                            "max_value": 1,
-                                                                                                            "shift_by": 3,
+                                                                                                            "shift_by": 15,
                                                                                                               "suffix": "",
                                                                                                                 "type": "integer"
                                                                                                      } ],
@@ -4730,11 +4730,11 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 4416,
+                                                                                                             "address": 4414,
                                                                                                          "description": "selector position",
-                                                                                                                "mask": 16,
+                                                                                                                "mask": 1,
                                                                                                            "max_value": 1,
-                                                                                                            "shift_by": 4,
+                                                                                                            "shift_by": 0,
                                                                                                               "suffix": "",
                                                                                                                 "type": "integer"
                                                                                                      } ],
@@ -4760,11 +4760,11 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 4416,
+                                                                                                             "address": 4414,
                                                                                                          "description": "selector position",
-                                                                                                                "mask": 1024,
+                                                                                                                "mask": 64,
                                                                                                            "max_value": 1,
-                                                                                                            "shift_by": 10,
+                                                                                                            "shift_by": 6,
                                                                                                               "suffix": "",
                                                                                                                 "type": "integer"
                                                                                                      } ],
@@ -4790,11 +4790,11 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 4418,
+                                                                                                             "address": 4416,
                                                                                                          "description": "selector position",
-                                                                                                                "mask": 8192,
+                                                                                                                "mask": 512,
                                                                                                            "max_value": 1,
-                                                                                                            "shift_by": 13,
+                                                                                                            "shift_by": 9,
                                                                                                               "suffix": "",
                                                                                                                 "type": "integer"
                                                                                                      } ],
@@ -4820,11 +4820,11 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 4418,
+                                                                                                             "address": 4416,
                                                                                                          "description": "selector position",
-                                                                                                                "mask": 16384,
+                                                                                                                "mask": 1024,
                                                                                                            "max_value": 1,
-                                                                                                            "shift_by": 14,
+                                                                                                            "shift_by": 10,
                                                                                                               "suffix": "",
                                                                                                                 "type": "integer"
                                                                                                      } ],
@@ -4850,11 +4850,11 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 4418,
+                                                                                                             "address": 4416,
                                                                                                          "description": "selector position",
-                                                                                                                "mask": 32768,
+                                                                                                                "mask": 2048,
                                                                                                            "max_value": 1,
-                                                                                                            "shift_by": 15,
+                                                                                                            "shift_by": 11,
                                                                                                               "suffix": "",
                                                                                                                 "type": "integer"
                                                                                                      } ],
@@ -4880,11 +4880,11 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 4420,
+                                                                                                             "address": 4416,
                                                                                                          "description": "selector position",
-                                                                                                                "mask": 8,
+                                                                                                                "mask": 32768,
                                                                                                            "max_value": 1,
-                                                                                                            "shift_by": 3,
+                                                                                                            "shift_by": 15,
                                                                                                               "suffix": "",
                                                                                                                 "type": "integer"
                                                                                                      } ],
@@ -4910,11 +4910,11 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 4420,
+                                                                                                             "address": 4416,
                                                                                                          "description": "selector position",
-                                                                                                                "mask": 1,
+                                                                                                                "mask": 4096,
                                                                                                            "max_value": 1,
-                                                                                                            "shift_by": 0,
+                                                                                                            "shift_by": 12,
                                                                                                               "suffix": "",
                                                                                                                 "type": "integer"
                                                                                                      } ],
@@ -4940,11 +4940,11 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 4418,
+                                                                                                             "address": 4414,
                                                                                                          "description": "selector position",
-                                                                                                                "mask": 1,
+                                                                                                                "mask": 4096,
                                                                                                            "max_value": 1,
-                                                                                                            "shift_by": 0,
+                                                                                                            "shift_by": 12,
                                                                                                               "suffix": "",
                                                                                                                 "type": "integer"
                                                                                                      } ],
@@ -4970,11 +4970,11 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 4418,
+                                                                                                             "address": 4414,
                                                                                                          "description": "selector position",
-                                                                                                                "mask": 2,
+                                                                                                                "mask": 8192,
                                                                                                            "max_value": 1,
-                                                                                                            "shift_by": 1,
+                                                                                                            "shift_by": 13,
                                                                                                               "suffix": "",
                                                                                                                 "type": "integer"
                                                                                                      } ],
@@ -5000,11 +5000,11 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 4418,
+                                                                                                             "address": 4416,
                                                                                                          "description": "selector position",
-                                                                                                                "mask": 4096,
+                                                                                                                "mask": 256,
                                                                                                            "max_value": 1,
-                                                                                                            "shift_by": 12,
+                                                                                                            "shift_by": 8,
                                                                                                               "suffix": "",
                                                                                                                 "type": "integer"
                                                                                                      } ],
@@ -5030,11 +5030,11 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 4416,
+                                                                                                             "address": 4414,
                                                                                                          "description": "selector position",
-                                                                                                                "mask": 32768,
+                                                                                                                "mask": 2048,
                                                                                                            "max_value": 1,
-                                                                                                            "shift_by": 15,
+                                                                                                            "shift_by": 11,
                                                                                                               "suffix": "",
                                                                                                                 "type": "integer"
                                                                                                      } ],
@@ -5060,11 +5060,11 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 4416,
+                                                                                                             "address": 4408,
                                                                                                          "description": "selector position",
-                                                                                                                "mask": 2,
+                                                                                                                "mask": 8192,
                                                                                                            "max_value": 1,
-                                                                                                            "shift_by": 1,
+                                                                                                            "shift_by": 13,
                                                                                                               "suffix": "",
                                                                                                                 "type": "integer"
                                                                                                      } ],
@@ -5090,11 +5090,11 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 4416,
+                                                                                                             "address": 4408,
                                                                                                          "description": "selector position",
-                                                                                                                "mask": 4,
+                                                                                                                "mask": 16384,
                                                                                                            "max_value": 1,
-                                                                                                            "shift_by": 2,
+                                                                                                            "shift_by": 14,
                                                                                                               "suffix": "",
                                                                                                                 "type": "integer"
                                                                                                      } ],
@@ -5120,11 +5120,11 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 4416,
+                                                                                                             "address": 4414,
                                                                                                          "description": "selector position",
-                                                                                                                "mask": 32,
+                                                                                                                "mask": 2,
                                                                                                            "max_value": 1,
-                                                                                                            "shift_by": 5,
+                                                                                                            "shift_by": 1,
                                                                                                               "suffix": "",
                                                                                                                 "type": "integer"
                                                                                                      } ],
@@ -5150,11 +5150,11 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 4416,
+                                                                                                             "address": 4414,
                                                                                                          "description": "selector position",
-                                                                                                                "mask": 64,
+                                                                                                                "mask": 4,
                                                                                                            "max_value": 1,
-                                                                                                            "shift_by": 6,
+                                                                                                            "shift_by": 2,
                                                                                                               "suffix": "",
                                                                                                                 "type": "integer"
                                                                                                      } ],
@@ -5180,11 +5180,11 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 4416,
+                                                                                                             "address": 4414,
                                                                                                          "description": "selector position",
-                                                                                                                "mask": 2048,
+                                                                                                                "mask": 128,
                                                                                                            "max_value": 1,
-                                                                                                            "shift_by": 11,
+                                                                                                            "shift_by": 7,
                                                                                                               "suffix": "",
                                                                                                                 "type": "integer"
                                                                                                      } ],
@@ -5210,11 +5210,11 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 4416,
+                                                                                                             "address": 4414,
                                                                                                          "description": "selector position",
-                                                                                                                "mask": 4096,
+                                                                                                                "mask": 256,
                                                                                                            "max_value": 1,
-                                                                                                            "shift_by": 12,
+                                                                                                            "shift_by": 8,
                                                                                                               "suffix": "",
                                                                                                                 "type": "integer"
                                                                                                      } ],
@@ -5240,11 +5240,11 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 4416,
+                                                                                                             "address": 4414,
                                                                                                          "description": "selector position",
-                                                                                                                "mask": 256,
+                                                                                                                "mask": 16,
                                                                                                            "max_value": 1,
-                                                                                                            "shift_by": 8,
+                                                                                                            "shift_by": 4,
                                                                                                               "suffix": "",
                                                                                                                 "type": "integer"
                                                                                                      } ],
@@ -5270,11 +5270,11 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 4416,
+                                                                                                             "address": 4414,
                                                                                                          "description": "selector position",
-                                                                                                                "mask": 512,
+                                                                                                                "mask": 32,
                                                                                                            "max_value": 1,
-                                                                                                            "shift_by": 9,
+                                                                                                            "shift_by": 5,
                                                                                                               "suffix": "",
                                                                                                                 "type": "integer"
                                                                                                      } ],
@@ -5300,11 +5300,11 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 4418,
+                                                                                                             "address": 4414,
                                                                                                          "description": "selector position",
-                                                                                                                "mask": 4,
+                                                                                                                "mask": 16384,
                                                                                                            "max_value": 1,
-                                                                                                            "shift_by": 2,
+                                                                                                            "shift_by": 14,
                                                                                                               "suffix": "",
                                                                                                                 "type": "integer"
                                                                                                      } ],
@@ -5330,11 +5330,11 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 4418,
+                                                                                                             "address": 4414,
                                                                                                          "description": "selector position",
-                                                                                                                "mask": 8,
+                                                                                                                "mask": 32768,
                                                                                                            "max_value": 1,
-                                                                                                            "shift_by": 3,
+                                                                                                            "shift_by": 15,
                                                                                                               "suffix": "",
                                                                                                                 "type": "integer"
                                                                                                      } ],
@@ -5360,11 +5360,11 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 4416,
+                                                                                                             "address": 4414,
                                                                                                          "description": "selector position",
-                                                                                                                "mask": 8192,
+                                                                                                                "mask": 512,
                                                                                                            "max_value": 1,
-                                                                                                            "shift_by": 13,
+                                                                                                            "shift_by": 9,
                                                                                                               "suffix": "",
                                                                                                                 "type": "integer"
                                                                                                      } ],
@@ -5390,11 +5390,11 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 4416,
+                                                                                                             "address": 4414,
                                                                                                          "description": "selector position",
-                                                                                                                "mask": 16384,
+                                                                                                                "mask": 1024,
                                                                                                            "max_value": 1,
-                                                                                                            "shift_by": 14,
+                                                                                                            "shift_by": 10,
                                                                                                               "suffix": "",
                                                                                                                 "type": "integer"
                                                                                                      } ],
@@ -5420,11 +5420,11 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 4416,
+                                                                                                             "address": 4414,
                                                                                                          "description": "selector position",
-                                                                                                                "mask": 128,
+                                                                                                                "mask": 8,
                                                                                                            "max_value": 1,
-                                                                                                            "shift_by": 7,
+                                                                                                            "shift_by": 3,
                                                                                                               "suffix": "",
                                                                                                                 "type": "integer"
                                                                                                      } ],
@@ -5450,11 +5450,11 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 4418,
+                                                                                                             "address": 4416,
                                                                                                          "description": "selector position",
-                                                                                                                "mask": 1024,
+                                                                                                                "mask": 64,
                                                                                                            "max_value": 1,
-                                                                                                            "shift_by": 10,
+                                                                                                            "shift_by": 6,
                                                                                                               "suffix": "",
                                                                                                                 "type": "integer"
                                                                                                      } ],
@@ -5480,11 +5480,11 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 4418,
+                                                                                                             "address": 4416,
                                                                                                          "description": "selector position",
-                                                                                                                "mask": 2048,
+                                                                                                                "mask": 128,
                                                                                                            "max_value": 1,
-                                                                                                            "shift_by": 11,
+                                                                                                            "shift_by": 7,
                                                                                                               "suffix": "",
                                                                                                                 "type": "integer"
                                                                                                      } ],
@@ -5510,11 +5510,11 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 4418,
+                                                                                                             "address": 4416,
                                                                                                          "description": "selector position",
-                                                                                                                "mask": 128,
+                                                                                                                "mask": 8,
                                                                                                            "max_value": 1,
-                                                                                                            "shift_by": 7,
+                                                                                                            "shift_by": 3,
                                                                                                               "suffix": "",
                                                                                                                 "type": "integer"
                                                                                                      } ],
@@ -5540,11 +5540,11 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 4418,
+                                                                                                             "address": 4416,
                                                                                                          "description": "selector position",
-                                                                                                                "mask": 512,
+                                                                                                                "mask": 32,
                                                                                                            "max_value": 1,
-                                                                                                            "shift_by": 9,
+                                                                                                            "shift_by": 5,
                                                                                                               "suffix": "",
                                                                                                                 "type": "integer"
                                                                                                      } ],
@@ -5570,11 +5570,11 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 4420,
+                                                                                                             "address": 4416,
                                                                                                          "description": "selector position",
-                                                                                                                "mask": 4,
+                                                                                                                "mask": 16384,
                                                                                                            "max_value": 1,
-                                                                                                            "shift_by": 2,
+                                                                                                            "shift_by": 14,
                                                                                                               "suffix": "",
                                                                                                                 "type": "integer"
                                                                                                      } ],
@@ -5600,11 +5600,11 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 4420,
+                                                                                                             "address": 4416,
                                                                                                          "description": "selector position",
-                                                                                                                "mask": 2,
+                                                                                                                "mask": 8192,
                                                                                                            "max_value": 1,
-                                                                                                            "shift_by": 1,
+                                                                                                            "shift_by": 13,
                                                                                                               "suffix": "",
                                                                                                                 "type": "integer"
                                                                                                      } ],
@@ -5630,11 +5630,11 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 4418,
+                                                                                                             "address": 4416,
                                                                                                          "description": "selector position",
-                                                                                                                "mask": 32,
+                                                                                                                "mask": 2,
                                                                                                            "max_value": 1,
-                                                                                                            "shift_by": 5,
+                                                                                                            "shift_by": 1,
                                                                                                               "suffix": "",
                                                                                                                 "type": "integer"
                                                                                                      } ],
@@ -5660,11 +5660,11 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 4418,
+                                                                                                             "address": 4416,
                                                                                                          "description": "selector position",
-                                                                                                                "mask": 64,
+                                                                                                                "mask": 4,
                                                                                                            "max_value": 1,
-                                                                                                            "shift_by": 6,
+                                                                                                            "shift_by": 2,
                                                                                                               "suffix": "",
                                                                                                                 "type": "integer"
                                                                                                      } ],
@@ -5690,11 +5690,11 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 4416,
+                                                                                                             "address": 4408,
                                                                                                          "description": "selector position",
-                                                                                                                "mask": 1,
+                                                                                                                "mask": 4096,
                                                                                                            "max_value": 1,
-                                                                                                            "shift_by": 0,
+                                                                                                            "shift_by": 12,
                                                                                                               "suffix": "",
                                                                                                                 "type": "integer"
                                                                                                      } ],
@@ -5720,11 +5720,11 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 4418,
+                                                                                                             "address": 4416,
                                                                                                          "description": "selector position",
-                                                                                                                "mask": 16,
+                                                                                                                "mask": 1,
                                                                                                            "max_value": 1,
-                                                                                                            "shift_by": 4,
+                                                                                                            "shift_by": 0,
                                                                                                               "suffix": "",
                                                                                                                 "type": "integer"
                                                                                                      } ],
@@ -5750,11 +5750,11 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 4418,
+                                                                                                             "address": 4416,
                                                                                                          "description": "selector position",
-                                                                                                                "mask": 256,
+                                                                                                                "mask": 16,
                                                                                                            "max_value": 1,
-                                                                                                            "shift_by": 8,
+                                                                                                            "shift_by": 4,
                                                                                                               "suffix": "",
                                                                                                                 "type": "integer"
                                                                                                      } ],
@@ -5769,11 +5769,11 @@
                                                                        "identifier": "DVADR_EOT",
                                                                            "inputs": [  ],
                                                                           "outputs": [ {
-                                                                                             "address": 4540,
+                                                                                             "address": 4538,
                                                                                          "description": "0 if light is off, 1 if light is on",
-                                                                                                "mask": 1024,
+                                                                                                "mask": 64,
                                                                                            "max_value": 1,
-                                                                                            "shift_by": 10,
+                                                                                            "shift_by": 6,
                                                                                               "suffix": "",
                                                                                                 "type": "integer"
                                                                                      } ]
@@ -5793,11 +5793,11 @@
                                                                                             } ],
                                                                      "momentary_positions": "none",
                                                                                  "outputs": [ {
-                                                                                                    "address": 4540,
+                                                                                                    "address": 4538,
                                                                                                 "description": "selector position",
-                                                                                                       "mask": 192,
+                                                                                                       "mask": 12,
                                                                                                   "max_value": 2,
-                                                                                                   "shift_by": 6,
+                                                                                                   "shift_by": 2,
                                                                                                      "suffix": "",
                                                                                                        "type": "integer"
                                                                                             } ],
@@ -5810,11 +5810,11 @@
                                                                        "identifier": "DVADR_REC",
                                                                            "inputs": [  ],
                                                                           "outputs": [ {
-                                                                                             "address": 4540,
+                                                                                             "address": 4538,
                                                                                          "description": "0 if light is off, 1 if light is on",
-                                                                                                "mask": 2048,
+                                                                                                "mask": 128,
                                                                                            "max_value": 1,
-                                                                                            "shift_by": 11,
+                                                                                            "shift_by": 7,
                                                                                               "suffix": "",
                                                                                                 "type": "integer"
                                                                                      } ]
@@ -5834,11 +5834,11 @@
                                                                                             } ],
                                                                      "momentary_positions": "none",
                                                                                  "outputs": [ {
-                                                                                                    "address": 4540,
+                                                                                                    "address": 4538,
                                                                                                 "description": "selector position",
-                                                                                                       "mask": 768,
+                                                                                                       "mask": 48,
                                                                                                   "max_value": 2,
-                                                                                                   "shift_by": 8,
+                                                                                                   "shift_by": 4,
                                                                                                      "suffix": "",
                                                                                                        "type": "integer"
                                                                                             } ],
@@ -5866,7 +5866,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4350,
+                                                                                                "address": 4348,
                                                                                             "description": "selector position",
                                                                                                    "mask": 2,
                                                                                               "max_value": 1,
@@ -5883,7 +5883,7 @@
                                                                    "identifier": "CLOCK_ETC",
                                                                        "inputs": [  ],
                                                                       "outputs": [ {
-                                                                                         "address": 4358,
+                                                                                         "address": 4356,
                                                                                      "description": "Clock ETC display ('ET ', '  C', or three spaces)",
                                                                                       "max_length": 3,
                                                                                           "suffix": "",
@@ -5897,7 +5897,7 @@
                                                                    "identifier": "CLOCK_HH",
                                                                        "inputs": [  ],
                                                                       "outputs": [ {
-                                                                                         "address": 4352,
+                                                                                         "address": 4350,
                                                                                      "description": "Clock Hours (or two spaces)",
                                                                                       "max_length": 2,
                                                                                           "suffix": "",
@@ -5911,7 +5911,7 @@
                                                                    "identifier": "CLOCK_MM",
                                                                        "inputs": [  ],
                                                                       "outputs": [ {
-                                                                                         "address": 4354,
+                                                                                         "address": 4352,
                                                                                      "description": "Clock Minutes (or two spaces)",
                                                                                       "max_length": 2,
                                                                                           "suffix": "",
@@ -5938,7 +5938,7 @@
                                                                                         } ],
                                                                  "momentary_positions": "none",
                                                                              "outputs": [ {
-                                                                                                "address": 4350,
+                                                                                                "address": 4348,
                                                                                             "description": "selector position",
                                                                                                    "mask": 1,
                                                                                               "max_value": 1,
@@ -5955,7 +5955,7 @@
                                                                    "identifier": "CLOCK_SS",
                                                                        "inputs": [  ],
                                                                       "outputs": [ {
-                                                                                         "address": 4356,
+                                                                                         "address": 4354,
                                                                                      "description": "Clock Seconds (or two spaces)",
                                                                                       "max_length": 2,
                                                                                           "suffix": "",
@@ -5983,7 +5983,7 @@
                                                                                               } ],
                                                                        "momentary_positions": "none",
                                                                                    "outputs": [ {
-                                                                                                      "address": 4366,
+                                                                                                      "address": 4364,
                                                                                                   "description": "selector position",
                                                                                                          "mask": 32768,
                                                                                                     "max_value": 1,
@@ -6012,7 +6012,7 @@
                                                                                               } ],
                                                                        "momentary_positions": "none",
                                                                                    "outputs": [ {
-                                                                                                      "address": 4370,
+                                                                                                      "address": 4368,
                                                                                                   "description": "selector position",
                                                                                                          "mask": 1,
                                                                                                     "max_value": 1,
@@ -6041,7 +6041,7 @@
                                                                                               } ],
                                                                        "momentary_positions": "none",
                                                                                    "outputs": [ {
-                                                                                                      "address": 4366,
+                                                                                                      "address": 4364,
                                                                                                   "description": "selector position",
                                                                                                          "mask": 4096,
                                                                                                     "max_value": 1,
@@ -6070,7 +6070,7 @@
                                                                                               } ],
                                                                        "momentary_positions": "none",
                                                                                    "outputs": [ {
-                                                                                                      "address": 4370,
+                                                                                                      "address": 4368,
                                                                                                   "description": "selector position",
                                                                                                          "mask": 2,
                                                                                                     "max_value": 1,
@@ -6099,7 +6099,7 @@
                                                                                               } ],
                                                                        "momentary_positions": "none",
                                                                                    "outputs": [ {
-                                                                                                      "address": 4370,
+                                                                                                      "address": 4368,
                                                                                                   "description": "selector position",
                                                                                                          "mask": 4,
                                                                                                     "max_value": 1,
@@ -6124,7 +6124,7 @@
                                                                                               } ],
                                                                        "momentary_positions": "none",
                                                                                    "outputs": [ {
-                                                                                                      "address": 4366,
+                                                                                                      "address": 4364,
                                                                                                   "description": "selector position",
                                                                                                          "mask": 24576,
                                                                                                     "max_value": 2,
@@ -6151,7 +6151,7 @@
                                                                                                           } ],
                                                                                    "momentary_positions": "none",
                                                                                                "outputs": [ {
-                                                                                                                  "address": 4366,
+                                                                                                                  "address": 4364,
                                                                                                               "description": "selector position",
                                                                                                                      "mask": 192,
                                                                                                                 "max_value": 2,
@@ -6176,7 +6176,7 @@
                                                                                                           } ],
                                                                                    "momentary_positions": "none",
                                                                                                "outputs": [ {
-                                                                                                                  "address": 4366,
+                                                                                                                  "address": 4364,
                                                                                                               "description": "selector position",
                                                                                                                      "mask": 768,
                                                                                                                 "max_value": 2,
@@ -6201,7 +6201,7 @@
                                                                                                           } ],
                                                                                    "momentary_positions": "none",
                                                                                                "outputs": [ {
-                                                                                                                  "address": 4366,
+                                                                                                                  "address": 4364,
                                                                                                               "description": "selector position",
                                                                                                                      "mask": 56,
                                                                                                                 "max_value": 4,
@@ -6230,7 +6230,7 @@
                                                                                                           } ],
                                                                                    "momentary_positions": "none",
                                                                                                "outputs": [ {
-                                                                                                                  "address": 4366,
+                                                                                                                  "address": 4364,
                                                                                                               "description": "selector position",
                                                                                                                      "mask": 1024,
                                                                                                                 "max_value": 1,
@@ -6259,7 +6259,7 @@
                                                                                                           } ],
                                                                                    "momentary_positions": "none",
                                                                                                "outputs": [ {
-                                                                                                                  "address": 4366,
+                                                                                                                  "address": 4364,
                                                                                                               "description": "selector position",
                                                                                                                      "mask": 2048,
                                                                                                                 "max_value": 1,
@@ -6288,7 +6288,7 @@
                                                                                                           } ],
                                                                                    "momentary_positions": "none",
                                                                                                "outputs": [ {
-                                                                                                                  "address": 4366,
+                                                                                                                  "address": 4364,
                                                                                                               "description": "selector position",
                                                                                                                      "mask": 2,
                                                                                                                 "max_value": 1,
@@ -6317,7 +6317,7 @@
                                                                                                           } ],
                                                                                    "momentary_positions": "none",
                                                                                                "outputs": [ {
-                                                                                                                  "address": 4366,
+                                                                                                                  "address": 4364,
                                                                                                               "description": "selector position",
                                                                                                                      "mask": 4,
                                                                                                                 "max_value": 1,
@@ -6334,7 +6334,7 @@
                                                                                      "identifier": "L_AILERON_EMER_DISENGAGE",
                                                                                          "inputs": [  ],
                                                                                         "outputs": [ {
-                                                                                                           "address": 4316,
+                                                                                                           "address": 4314,
                                                                                                        "description": "0 if light is off, 1 if light is on",
                                                                                                               "mask": 64,
                                                                                                          "max_value": 1,
@@ -6350,7 +6350,7 @@
                                                                                      "identifier": "L_ELEVATOR_EMER_DISENGAGE",
                                                                                          "inputs": [  ],
                                                                                         "outputs": [ {
-                                                                                                           "address": 4316,
+                                                                                                           "address": 4314,
                                                                                                        "description": "0 if light is off, 1 if light is on",
                                                                                                               "mask": 256,
                                                                                                          "max_value": 1,
@@ -6366,7 +6366,7 @@
                                                                                      "identifier": "R_AILERON_EMER_DISENGAGE",
                                                                                          "inputs": [  ],
                                                                                         "outputs": [ {
-                                                                                                           "address": 4316,
+                                                                                                           "address": 4314,
                                                                                                        "description": "0 if light is off, 1 if light is on",
                                                                                                               "mask": 128,
                                                                                                          "max_value": 1,
@@ -6382,7 +6382,7 @@
                                                                                      "identifier": "R_ELEVATOR_EMER_DISENGAGE",
                                                                                          "inputs": [  ],
                                                                                         "outputs": [ {
-                                                                                                           "address": 4316,
+                                                                                                           "address": 4314,
                                                                                                        "description": "0 if light is off, 1 if light is on",
                                                                                                               "mask": 512,
                                                                                                          "max_value": 1,
@@ -6722,7 +6722,7 @@
                                                                                "identifier": "CABIN_PRESS_ALT",
                                                                                    "inputs": [  ],
                                                                                   "outputs": [ {
-                                                                                                     "address": 4406,
+                                                                                                     "address": 4404,
                                                                                                  "description": "gauge position",
                                                                                                         "mask": 65535,
                                                                                                    "max_value": 65535,
@@ -6748,9 +6748,9 @@
                                                                                          "outputs": [ {
                                                                                                             "address": 4408,
                                                                                                         "description": "selector position",
-                                                                                                               "mask": 12288,
+                                                                                                               "mask": 768,
                                                                                                           "max_value": 3,
-                                                                                                           "shift_by": 12,
+                                                                                                           "shift_by": 8,
                                                                                                              "suffix": "",
                                                                                                                "type": "integer"
                                                                                                     } ],
@@ -6777,9 +6777,9 @@
                                                                                          "outputs": [ {
                                                                                                             "address": 4408,
                                                                                                         "description": "selector position",
-                                                                                                               "mask": 2048,
+                                                                                                               "mask": 128,
                                                                                                           "max_value": 1,
-                                                                                                           "shift_by": 11,
+                                                                                                           "shift_by": 7,
                                                                                                              "suffix": "",
                                                                                                                "type": "integer"
                                                                                                     } ],
@@ -6806,9 +6806,9 @@
                                                                                          "outputs": [ {
                                                                                                             "address": 4408,
                                                                                                         "description": "selector position",
-                                                                                                               "mask": 32,
+                                                                                                               "mask": 2,
                                                                                                           "max_value": 1,
-                                                                                                           "shift_by": 5,
+                                                                                                           "shift_by": 1,
                                                                                                              "suffix": "",
                                                                                                                "type": "integer"
                                                                                                     } ],
@@ -6830,7 +6830,7 @@
                                                                                                  "suggested_step": 3200
                                                                                              } ],
                                                                                   "outputs": [ {
-                                                                                                     "address": 4410,
+                                                                                                     "address": 4406,
                                                                                                  "description": "position of the potentiometer",
                                                                                                         "mask": 65535,
                                                                                                    "max_value": 65535,
@@ -6855,7 +6855,7 @@
                                                                                                  "suggested_step": 3200
                                                                                              } ],
                                                                                   "outputs": [ {
-                                                                                                     "address": 4412,
+                                                                                                     "address": 4410,
                                                                                                  "description": "position of the potentiometer",
                                                                                                         "mask": 65535,
                                                                                                    "max_value": 65535,
@@ -6884,11 +6884,11 @@
                                                                                                     } ],
                                                                              "momentary_positions": "none",
                                                                                          "outputs": [ {
-                                                                                                            "address": 4408,
+                                                                                                            "address": 4394,
                                                                                                         "description": "selector position",
-                                                                                                               "mask": 1,
+                                                                                                               "mask": 4096,
                                                                                                           "max_value": 1,
-                                                                                                           "shift_by": 0,
+                                                                                                           "shift_by": 12,
                                                                                                              "suffix": "",
                                                                                                                "type": "integer"
                                                                                                     } ],
@@ -6915,9 +6915,9 @@
                                                                                          "outputs": [ {
                                                                                                             "address": 4408,
                                                                                                         "description": "selector position",
-                                                                                                               "mask": 16,
+                                                                                                               "mask": 1,
                                                                                                           "max_value": 1,
-                                                                                                           "shift_by": 4,
+                                                                                                           "shift_by": 0,
                                                                                                              "suffix": "",
                                                                                                                "type": "integer"
                                                                                                     } ],
@@ -6939,7 +6939,7 @@
                                                                                                  "suggested_step": 3200
                                                                                              } ],
                                                                                   "outputs": [ {
-                                                                                                     "address": 4414,
+                                                                                                     "address": 4412,
                                                                                                  "description": "position of the potentiometer",
                                                                                                         "mask": 65535,
                                                                                                    "max_value": 65535,
@@ -6965,9 +6965,9 @@
                                                                                          "outputs": [ {
                                                                                                             "address": 4408,
                                                                                                         "description": "selector position",
-                                                                                                               "mask": 192,
+                                                                                                               "mask": 12,
                                                                                                           "max_value": 2,
-                                                                                                           "shift_by": 6,
+                                                                                                           "shift_by": 2,
                                                                                                              "suffix": "",
                                                                                                                "type": "integer"
                                                                                                     } ],
@@ -6992,11 +6992,11 @@
                                                                                                     } ],
                                                                              "momentary_positions": "none",
                                                                                          "outputs": [ {
-                                                                                                            "address": 4408,
+                                                                                                            "address": 4394,
                                                                                                         "description": "selector position",
-                                                                                                               "mask": 2,
+                                                                                                               "mask": 8192,
                                                                                                           "max_value": 1,
-                                                                                                           "shift_by": 1,
+                                                                                                           "shift_by": 13,
                                                                                                              "suffix": "",
                                                                                                                "type": "integer"
                                                                                                     } ],
@@ -7017,11 +7017,11 @@
                                                                                                     } ],
                                                                              "momentary_positions": "none",
                                                                                          "outputs": [ {
-                                                                                                            "address": 4408,
+                                                                                                            "address": 4394,
                                                                                                         "description": "selector position",
-                                                                                                               "mask": 12,
+                                                                                                               "mask": 49152,
                                                                                                           "max_value": 2,
-                                                                                                           "shift_by": 2,
+                                                                                                           "shift_by": 14,
                                                                                                              "suffix": "",
                                                                                                                "type": "integer"
                                                                                                     } ],
@@ -7034,7 +7034,7 @@
                                                                                "identifier": "OXY_VOLUME",
                                                                                    "inputs": [  ],
                                                                                   "outputs": [ {
-                                                                                                     "address": 4404,
+                                                                                                     "address": 4402,
                                                                                                  "description": "gauge position",
                                                                                                         "mask": 65535,
                                                                                                    "max_value": 65535,
@@ -7052,7 +7052,7 @@
                                                                                  "identifier": "EXT_FORMATION_LIGHTS",
                                                                                      "inputs": [  ],
                                                                                     "outputs": [ {
-                                                                                                       "address": 4816,
+                                                                                                       "address": 4814,
                                                                                                    "description": "Formation Lights",
                                                                                                           "mask": 65535,
                                                                                                      "max_value": 65535,
@@ -7068,11 +7068,11 @@
                                                                                  "identifier": "EXT_POSITION_LIGHT_LEFT",
                                                                                      "inputs": [  ],
                                                                                     "outputs": [ {
-                                                                                                       "address": 4542,
+                                                                                                       "address": 4540,
                                                                                                    "description": "Left Position Light (red)",
-                                                                                                          "mask": 32768,
+                                                                                                          "mask": 2048,
                                                                                                      "max_value": 1,
-                                                                                                      "shift_by": 15,
+                                                                                                      "shift_by": 11,
                                                                                                         "suffix": "",
                                                                                                           "type": "integer"
                                                                                                } ]
@@ -7084,11 +7084,11 @@
                                                                                  "identifier": "EXT_POSITION_LIGHT_RIGHT",
                                                                                      "inputs": [  ],
                                                                                     "outputs": [ {
-                                                                                                       "address": 4800,
+                                                                                                       "address": 4540,
                                                                                                    "description": "Right Position Light (green)",
-                                                                                                          "mask": 256,
+                                                                                                          "mask": 4096,
                                                                                                      "max_value": 1,
-                                                                                                      "shift_by": 8,
+                                                                                                      "shift_by": 12,
                                                                                                         "suffix": "",
                                                                                                           "type": "integer"
                                                                                                } ]
@@ -7100,7 +7100,7 @@
                                                                                  "identifier": "EXT_SPEED_BRAKE_LEFT",
                                                                                      "inputs": [  ],
                                                                                     "outputs": [ {
-                                                                                                       "address": 4814,
+                                                                                                       "address": 4812,
                                                                                                    "description": "Left Speed Brake",
                                                                                                           "mask": 65535,
                                                                                                      "max_value": 65535,
@@ -7116,7 +7116,7 @@
                                                                                  "identifier": "EXT_SPEED_BRAKE_RIGHT",
                                                                                      "inputs": [  ],
                                                                                     "outputs": [ {
-                                                                                                       "address": 4812,
+                                                                                                       "address": 4810,
                                                                                                    "description": "Right Speed Brake",
                                                                                                           "mask": 65535,
                                                                                                      "max_value": 65535,
@@ -7132,11 +7132,11 @@
                                                                                  "identifier": "EXT_STROBE_LEFT",
                                                                                      "inputs": [  ],
                                                                                     "outputs": [ {
-                                                                                                       "address": 4800,
+                                                                                                       "address": 4540,
                                                                                                    "description": "Left Strobe Light",
-                                                                                                          "mask": 1024,
+                                                                                                          "mask": 16384,
                                                                                                      "max_value": 1,
-                                                                                                      "shift_by": 10,
+                                                                                                      "shift_by": 14,
                                                                                                         "suffix": "",
                                                                                                           "type": "integer"
                                                                                                } ]
@@ -7148,11 +7148,11 @@
                                                                                  "identifier": "EXT_STROBE_RIGHT",
                                                                                      "inputs": [  ],
                                                                                     "outputs": [ {
-                                                                                                       "address": 4800,
+                                                                                                       "address": 4540,
                                                                                                    "description": "Right Strobe Light",
-                                                                                                          "mask": 2048,
+                                                                                                          "mask": 32768,
                                                                                                      "max_value": 1,
-                                                                                                      "shift_by": 11,
+                                                                                                      "shift_by": 15,
                                                                                                         "suffix": "",
                                                                                                           "type": "integer"
                                                                                                } ]
@@ -7164,11 +7164,11 @@
                                                                                  "identifier": "EXT_STROBE_TAIL",
                                                                                      "inputs": [  ],
                                                                                     "outputs": [ {
-                                                                                                       "address": 4800,
+                                                                                                       "address": 4540,
                                                                                                    "description": "Tail Strobe Light",
-                                                                                                          "mask": 512,
+                                                                                                          "mask": 8192,
                                                                                                      "max_value": 1,
-                                                                                                      "shift_by": 9,
+                                                                                                      "shift_by": 13,
                                                                                                         "suffix": "",
                                                                                                           "type": "integer"
                                                                                                } ]
@@ -7182,7 +7182,7 @@
                                                                            "identifier": "CANOPY_UNLOCKED",
                                                                                "inputs": [  ],
                                                                               "outputs": [ {
-                                                                                                 "address": 4316,
+                                                                                                 "address": 4314,
                                                                                              "description": "0 if light is off, 1 if light is on",
                                                                                                     "mask": 4,
                                                                                                "max_value": 1,
@@ -7214,7 +7214,7 @@
                                                                            "identifier": "MARKER_BEACON",
                                                                                "inputs": [  ],
                                                                               "outputs": [ {
-                                                                                                 "address": 4316,
+                                                                                                 "address": 4314,
                                                                                              "description": "0 if light is off, 1 if light is on",
                                                                                                     "mask": 2,
                                                                                                "max_value": 1,
@@ -7230,7 +7230,7 @@
                                                                            "identifier": "NOSEWHEEL_STEERING",
                                                                                "inputs": [  ],
                                                                               "outputs": [ {
-                                                                                                 "address": 4316,
+                                                                                                 "address": 4314,
                                                                                              "description": "0 if light is off, 1 if light is on",
                                                                                                     "mask": 1,
                                                                                                "max_value": 1,
@@ -7256,7 +7256,7 @@
                                                                                             } ],
                                                                      "momentary_positions": "none",
                                                                                  "outputs": [ {
-                                                                                                    "address": 4360,
+                                                                                                    "address": 4358,
                                                                                                 "description": "selector position",
                                                                                                        "mask": 7168,
                                                                                                   "max_value": 4,
@@ -7286,7 +7286,7 @@
                                                                                             } ],
                                                                      "momentary_positions": "none",
                                                                                  "outputs": [ {
-                                                                                                    "address": 4360,
+                                                                                                    "address": 4358,
                                                                                                 "description": "selector position",
                                                                                                        "mask": 512,
                                                                                                   "max_value": 1,
@@ -7397,7 +7397,7 @@
                                                                                                  } ],
                                                                           "momentary_positions": "none",
                                                                                       "outputs": [ {
-                                                                                                         "address": 4350,
+                                                                                                         "address": 4348,
                                                                                                      "description": "selector position",
                                                                                                             "mask": 1024,
                                                                                                        "max_value": 1,
@@ -7426,7 +7426,7 @@
                                                                                                  } ],
                                                                           "momentary_positions": "none",
                                                                                       "outputs": [ {
-                                                                                                         "address": 4350,
+                                                                                                         "address": 4348,
                                                                                                      "description": "selector position",
                                                                                                             "mask": 256,
                                                                                                        "max_value": 1,
@@ -7455,7 +7455,7 @@
                                                                                                  } ],
                                                                           "momentary_positions": "none",
                                                                                       "outputs": [ {
-                                                                                                         "address": 4350,
+                                                                                                         "address": 4348,
                                                                                                      "description": "selector position",
                                                                                                             "mask": 512,
                                                                                                        "max_value": 1,
@@ -7484,7 +7484,7 @@
                                                                                                  } ],
                                                                           "momentary_positions": "none",
                                                                                       "outputs": [ {
-                                                                                                         "address": 4350,
+                                                                                                         "address": 4348,
                                                                                                      "description": "selector position",
                                                                                                             "mask": 64,
                                                                                                        "max_value": 1,
@@ -7513,7 +7513,7 @@
                                                                                                  } ],
                                                                           "momentary_positions": "none",
                                                                                       "outputs": [ {
-                                                                                                         "address": 4350,
+                                                                                                         "address": 4348,
                                                                                                      "description": "selector position",
                                                                                                             "mask": 128,
                                                                                                        "max_value": 1,
@@ -7542,7 +7542,7 @@
                                                                                                  } ],
                                                                           "momentary_positions": "none",
                                                                                       "outputs": [ {
-                                                                                                         "address": 4350,
+                                                                                                         "address": 4348,
                                                                                                      "description": "selector position",
                                                                                                             "mask": 32,
                                                                                                        "max_value": 1,
@@ -7571,7 +7571,7 @@
                                                                                                  } ],
                                                                           "momentary_positions": "none",
                                                                                       "outputs": [ {
-                                                                                                         "address": 4350,
+                                                                                                         "address": 4348,
                                                                                                      "description": "selector position",
                                                                                                             "mask": 8,
                                                                                                        "max_value": 1,
@@ -7600,7 +7600,7 @@
                                                                                                  } ],
                                                                           "momentary_positions": "none",
                                                                                       "outputs": [ {
-                                                                                                         "address": 4350,
+                                                                                                         "address": 4348,
                                                                                                      "description": "selector position",
                                                                                                             "mask": 4,
                                                                                                        "max_value": 1,
@@ -7630,7 +7630,7 @@
                                                                                                  } ],
                                                                           "momentary_positions": "none",
                                                                                       "outputs": [ {
-                                                                                                         "address": 4350,
+                                                                                                         "address": 4348,
                                                                                                      "description": "selector position",
                                                                                                             "mask": 16384,
                                                                                                        "max_value": 1,
@@ -7660,7 +7660,7 @@
                                                                                                  } ],
                                                                           "momentary_positions": "none",
                                                                                       "outputs": [ {
-                                                                                                         "address": 4350,
+                                                                                                         "address": 4348,
                                                                                                      "description": "selector position",
                                                                                                             "mask": 32768,
                                                                                                        "max_value": 1,
@@ -7690,7 +7690,7 @@
                                                                                                  } ],
                                                                           "momentary_positions": "none",
                                                                                       "outputs": [ {
-                                                                                                         "address": 4350,
+                                                                                                         "address": 4348,
                                                                                                      "description": "selector position",
                                                                                                             "mask": 4096,
                                                                                                        "max_value": 1,
@@ -7720,7 +7720,7 @@
                                                                                                  } ],
                                                                           "momentary_positions": "none",
                                                                                       "outputs": [ {
-                                                                                                         "address": 4350,
+                                                                                                         "address": 4348,
                                                                                                      "description": "selector position",
                                                                                                             "mask": 8192,
                                                                                                        "max_value": 1,
@@ -7750,7 +7750,7 @@
                                                                                                  } ],
                                                                           "momentary_positions": "none",
                                                                                       "outputs": [ {
-                                                                                                         "address": 4350,
+                                                                                                         "address": 4348,
                                                                                                      "description": "selector position",
                                                                                                             "mask": 2048,
                                                                                                        "max_value": 1,
@@ -7779,7 +7779,7 @@
                                                                                                  } ],
                                                                           "momentary_positions": "none",
                                                                                       "outputs": [ {
-                                                                                                         "address": 4360,
+                                                                                                         "address": 4358,
                                                                                                      "description": "selector position",
                                                                                                             "mask": 256,
                                                                                                        "max_value": 1,
@@ -7808,7 +7808,7 @@
                                                                                                  } ],
                                                                           "momentary_positions": "none",
                                                                                       "outputs": [ {
-                                                                                                         "address": 4350,
+                                                                                                         "address": 4348,
                                                                                                      "description": "selector position",
                                                                                                             "mask": 16,
                                                                                                        "max_value": 1,
@@ -7827,7 +7827,7 @@
                                                                             "identifier": "APU_FIRE",
                                                                                 "inputs": [  ],
                                                                                "outputs": [ {
-                                                                                                  "address": 4316,
+                                                                                                  "address": 4314,
                                                                                               "description": "0 if light is off, 1 if light is on",
                                                                                                      "mask": 16,
                                                                                                 "max_value": 1,
@@ -7856,11 +7856,11 @@
                                                                                                  } ],
                                                                           "momentary_positions": "none",
                                                                                       "outputs": [ {
-                                                                                                         "address": 4380,
+                                                                                                         "address": 4374,
                                                                                                      "description": "selector position",
-                                                                                                            "mask": 16384,
+                                                                                                            "mask": 8192,
                                                                                                        "max_value": 1,
-                                                                                                        "shift_by": 14,
+                                                                                                        "shift_by": 13,
                                                                                                           "suffix": "",
                                                                                                             "type": "integer"
                                                                                                  } ],
@@ -7885,11 +7885,11 @@
                                                                                                  } ],
                                                                           "momentary_positions": "none",
                                                                                       "outputs": [ {
-                                                                                                         "address": 4436,
+                                                                                                         "address": 4440,
                                                                                                      "description": "selector position",
-                                                                                                            "mask": 64,
+                                                                                                            "mask": 4,
                                                                                                        "max_value": 1,
-                                                                                                        "shift_by": 6,
+                                                                                                        "shift_by": 2,
                                                                                                           "suffix": "",
                                                                                                             "type": "integer"
                                                                                                  } ],
@@ -7910,11 +7910,11 @@
                                                                                                  } ],
                                                                           "momentary_positions": "none",
                                                                                       "outputs": [ {
-                                                                                                         "address": 4436,
+                                                                                                         "address": 4440,
                                                                                                      "description": "selector position",
-                                                                                                            "mask": 768,
+                                                                                                            "mask": 48,
                                                                                                        "max_value": 2,
-                                                                                                        "shift_by": 8,
+                                                                                                        "shift_by": 4,
                                                                                                           "suffix": "",
                                                                                                             "type": "integer"
                                                                                                  } ],
@@ -7939,11 +7939,11 @@
                                                                                                  } ],
                                                                           "momentary_positions": "none",
                                                                                       "outputs": [ {
-                                                                                                         "address": 4436,
+                                                                                                         "address": 4440,
                                                                                                      "description": "selector position",
-                                                                                                            "mask": 32,
+                                                                                                            "mask": 2,
                                                                                                        "max_value": 1,
-                                                                                                        "shift_by": 5,
+                                                                                                        "shift_by": 1,
                                                                                                           "suffix": "",
                                                                                                             "type": "integer"
                                                                                                  } ],
@@ -7968,11 +7968,11 @@
                                                                                                  } ],
                                                                           "momentary_positions": "none",
                                                                                       "outputs": [ {
-                                                                                                         "address": 4436,
+                                                                                                         "address": 4440,
                                                                                                      "description": "selector position",
-                                                                                                            "mask": 128,
+                                                                                                            "mask": 8,
                                                                                                        "max_value": 1,
-                                                                                                        "shift_by": 7,
+                                                                                                        "shift_by": 3,
                                                                                                           "suffix": "",
                                                                                                             "type": "integer"
                                                                                                  } ],
@@ -7985,7 +7985,7 @@
                                                                             "identifier": "L_ENG_FIRE",
                                                                                 "inputs": [  ],
                                                                                "outputs": [ {
-                                                                                                  "address": 4316,
+                                                                                                  "address": 4314,
                                                                                               "description": "0 if light is off, 1 if light is on",
                                                                                                      "mask": 8,
                                                                                                 "max_value": 1,
@@ -8001,7 +8001,7 @@
                                                                             "identifier": "R_ENG_FIRE",
                                                                                 "inputs": [  ],
                                                                                "outputs": [ {
-                                                                                                  "address": 4316,
+                                                                                                  "address": 4314,
                                                                                               "description": "0 if light is off, 1 if light is on",
                                                                                                      "mask": 32,
                                                                                                 "max_value": 1,
@@ -8032,11 +8032,11 @@
                                                                                              } ],
                                                                       "momentary_positions": "none",
                                                                                   "outputs": [ {
-                                                                                                     "address": 4514,
+                                                                                                     "address": 4518,
                                                                                                  "description": "selector position",
-                                                                                                        "mask": 32768,
+                                                                                                        "mask": 2048,
                                                                                                    "max_value": 1,
-                                                                                                    "shift_by": 15,
+                                                                                                    "shift_by": 11,
                                                                                                       "suffix": "",
                                                                                                         "type": "integer"
                                                                                              } ],
@@ -8058,7 +8058,7 @@
                                                                                           "suggested_step": 3200
                                                                                       } ],
                                                                            "outputs": [ {
-                                                                                              "address": 4538,
+                                                                                              "address": 4534,
                                                                                           "description": "position of the potentiometer",
                                                                                                  "mask": 65535,
                                                                                             "max_value": 65535,
@@ -8083,7 +8083,7 @@
                                                                                           "suggested_step": 3200
                                                                                       } ],
                                                                            "outputs": [ {
-                                                                                              "address": 4536,
+                                                                                              "address": 4532,
                                                                                           "description": "position of the potentiometer",
                                                                                                  "mask": 65535,
                                                                                             "max_value": 65535,
@@ -8107,11 +8107,11 @@
                                                                                              } ],
                                                                       "momentary_positions": "none",
                                                                                   "outputs": [ {
-                                                                                                     "address": 4534,
+                                                                                                     "address": 4518,
                                                                                                  "description": "selector position",
-                                                                                                        "mask": 12,
+                                                                                                        "mask": 49152,
                                                                                                    "max_value": 2,
-                                                                                                    "shift_by": 2,
+                                                                                                    "shift_by": 14,
                                                                                                       "suffix": "",
                                                                                                         "type": "integer"
                                                                                              } ],
@@ -8136,11 +8136,11 @@
                                                                                              } ],
                                                                       "momentary_positions": "none",
                                                                                   "outputs": [ {
-                                                                                                     "address": 4534,
+                                                                                                     "address": 4518,
                                                                                                  "description": "selector position",
-                                                                                                        "mask": 2,
+                                                                                                        "mask": 8192,
                                                                                                    "max_value": 1,
-                                                                                                    "shift_by": 1,
+                                                                                                    "shift_by": 13,
                                                                                                       "suffix": "",
                                                                                                         "type": "integer"
                                                                                              } ],
@@ -8166,11 +8166,11 @@
                                                                                              } ],
                                                                       "momentary_positions": "none",
                                                                                   "outputs": [ {
-                                                                                                     "address": 4534,
+                                                                                                     "address": 4536,
                                                                                                  "description": "selector position",
-                                                                                                        "mask": 16,
+                                                                                                        "mask": 1,
                                                                                                    "max_value": 1,
-                                                                                                    "shift_by": 4,
+                                                                                                    "shift_by": 0,
                                                                                                       "suffix": "",
                                                                                                         "type": "integer"
                                                                                              } ],
@@ -8195,11 +8195,11 @@
                                                                                              } ],
                                                                       "momentary_positions": "none",
                                                                                   "outputs": [ {
-                                                                                                     "address": 4534,
+                                                                                                     "address": 4518,
                                                                                                  "description": "selector position",
-                                                                                                        "mask": 1,
+                                                                                                        "mask": 4096,
                                                                                                    "max_value": 1,
-                                                                                                    "shift_by": 0,
+                                                                                                    "shift_by": 12,
                                                                                                       "suffix": "",
                                                                                                         "type": "integer"
                                                                                              } ],
@@ -8331,7 +8331,7 @@
                                                                                            "suggested_step": 3200
                                                                                        } ],
                                                                             "outputs": [ {
-                                                                                               "address": 4444,
+                                                                                               "address": 4442,
                                                                                            "description": "rotation of the knob (not the value being manipulated!)",
                                                                                                   "mask": 65535,
                                                                                              "max_value": 65535,
@@ -8400,7 +8400,7 @@
                                                                                            "suggested_step": 3200
                                                                                        } ],
                                                                             "outputs": [ {
-                                                                                               "address": 4446,
+                                                                                               "address": 4444,
                                                                                            "description": "rotation of the knob (not the value being manipulated!)",
                                                                                                   "mask": 65535,
                                                                                              "max_value": 65535,
@@ -8648,11 +8648,11 @@
                                                                                                  } ],
                                                                           "momentary_positions": "none",
                                                                                       "outputs": [ {
-                                                                                                         "address": 4388,
+                                                                                                         "address": 4378,
                                                                                                      "description": "selector position",
-                                                                                                            "mask": 24576,
+                                                                                                            "mask": 49152,
                                                                                                        "max_value": 3,
-                                                                                                        "shift_by": 13,
+                                                                                                        "shift_by": 14,
                                                                                                           "suffix": "",
                                                                                                             "type": "integer"
                                                                                                  } ],
@@ -8673,11 +8673,11 @@
                                                                                                  } ],
                                                                           "momentary_positions": "none",
                                                                                       "outputs": [ {
-                                                                                                         "address": 4392,
+                                                                                                         "address": 4382,
                                                                                                      "description": "selector position",
-                                                                                                            "mask": 1792,
+                                                                                                            "mask": 57344,
                                                                                                        "max_value": 4,
-                                                                                                        "shift_by": 8,
+                                                                                                        "shift_by": 13,
                                                                                                           "suffix": "",
                                                                                                             "type": "integer"
                                                                                                  } ],
@@ -8698,11 +8698,11 @@
                                                                                                  } ],
                                                                           "momentary_positions": "none",
                                                                                       "outputs": [ {
-                                                                                                         "address": 4394,
+                                                                                                         "address": 4392,
                                                                                                      "description": "selector position",
-                                                                                                            "mask": 768,
+                                                                                                            "mask": 12,
                                                                                                        "max_value": 2,
-                                                                                                        "shift_by": 8,
+                                                                                                        "shift_by": 2,
                                                                                                           "suffix": "",
                                                                                                             "type": "integer"
                                                                                                  } ],
@@ -8723,11 +8723,11 @@
                                                                                                  } ],
                                                                           "momentary_positions": "none",
                                                                                       "outputs": [ {
-                                                                                                         "address": 4394,
+                                                                                                         "address": 4392,
                                                                                                      "description": "selector position",
-                                                                                                            "mask": 7168,
+                                                                                                            "mask": 112,
                                                                                                        "max_value": 7,
-                                                                                                        "shift_by": 10,
+                                                                                                        "shift_by": 4,
                                                                                                           "suffix": "",
                                                                                                             "type": "integer"
                                                                                                  } ],
@@ -8748,11 +8748,11 @@
                                                                                                  } ],
                                                                           "momentary_positions": "none",
                                                                                       "outputs": [ {
-                                                                                                         "address": 4394,
+                                                                                                         "address": 4392,
                                                                                                      "description": "selector position",
-                                                                                                            "mask": 24576,
+                                                                                                            "mask": 384,
                                                                                                        "max_value": 3,
-                                                                                                        "shift_by": 13,
+                                                                                                        "shift_by": 7,
                                                                                                           "suffix": "",
                                                                                                             "type": "integer"
                                                                                                  } ],
@@ -8773,11 +8773,11 @@
                                                                                                  } ],
                                                                           "momentary_positions": "none",
                                                                                       "outputs": [ {
-                                                                                                         "address": 4396,
+                                                                                                         "address": 4392,
                                                                                                      "description": "selector position",
-                                                                                                            "mask": 7,
+                                                                                                            "mask": 3584,
                                                                                                        "max_value": 7,
-                                                                                                        "shift_by": 0,
+                                                                                                        "shift_by": 9,
                                                                                                           "suffix": "",
                                                                                                             "type": "integer"
                                                                                                  } ],
@@ -8798,11 +8798,11 @@
                                                                                                  } ],
                                                                           "momentary_positions": "none",
                                                                                       "outputs": [ {
-                                                                                                         "address": 4396,
+                                                                                                         "address": 4392,
                                                                                                      "description": "selector position",
-                                                                                                            "mask": 56,
+                                                                                                            "mask": 28672,
                                                                                                        "max_value": 7,
-                                                                                                        "shift_by": 3,
+                                                                                                        "shift_by": 12,
                                                                                                           "suffix": "",
                                                                                                             "type": "integer"
                                                                                                  } ],
@@ -8823,11 +8823,11 @@
                                                                                                  } ],
                                                                           "momentary_positions": "none",
                                                                                       "outputs": [ {
-                                                                                                         "address": 4396,
+                                                                                                         "address": 4394,
                                                                                                      "description": "selector position",
-                                                                                                            "mask": 448,
+                                                                                                            "mask": 7,
                                                                                                        "max_value": 7,
-                                                                                                        "shift_by": 6,
+                                                                                                        "shift_by": 0,
                                                                                                           "suffix": "",
                                                                                                             "type": "integer"
                                                                                                  } ],
@@ -8848,11 +8848,11 @@
                                                                                                  } ],
                                                                           "momentary_positions": "none",
                                                                                       "outputs": [ {
-                                                                                                         "address": 4396,
+                                                                                                         "address": 4394,
                                                                                                      "description": "selector position",
-                                                                                                            "mask": 3584,
+                                                                                                            "mask": 56,
                                                                                                        "max_value": 7,
-                                                                                                        "shift_by": 9,
+                                                                                                        "shift_by": 3,
                                                                                                           "suffix": "",
                                                                                                             "type": "integer"
                                                                                                  } ],
@@ -8877,7 +8877,7 @@
                                                                                                  } ],
                                                                           "momentary_positions": "none",
                                                                                       "outputs": [ {
-                                                                                                         "address": 4384,
+                                                                                                         "address": 4386,
                                                                                                      "description": "selector position",
                                                                                                             "mask": 32768,
                                                                                                        "max_value": 1,
@@ -8902,11 +8902,11 @@
                                                                                                  } ],
                                                                           "momentary_positions": "none",
                                                                                       "outputs": [ {
-                                                                                                         "address": 4392,
+                                                                                                         "address": 4386,
                                                                                                      "description": "selector position",
-                                                                                                            "mask": 6144,
+                                                                                                            "mask": 24576,
                                                                                                        "max_value": 2,
-                                                                                                        "shift_by": 11,
+                                                                                                        "shift_by": 13,
                                                                                                           "suffix": "",
                                                                                                             "type": "integer"
                                                                                                  } ],
@@ -8927,11 +8927,11 @@
                                                                                                  } ],
                                                                           "momentary_positions": "none",
                                                                                       "outputs": [ {
-                                                                                                         "address": 4394,
+                                                                                                         "address": 4392,
                                                                                                      "description": "selector position",
-                                                                                                            "mask": 192,
+                                                                                                            "mask": 3,
                                                                                                        "max_value": 2,
-                                                                                                        "shift_by": 6,
+                                                                                                        "shift_by": 0,
                                                                                                           "suffix": "",
                                                                                                             "type": "integer"
                                                                                                  } ],
@@ -8953,7 +8953,7 @@
                                                                                               "suggested_step": 3200
                                                                                           } ],
                                                                                "outputs": [ {
-                                                                                                  "address": 4398,
+                                                                                                  "address": 4396,
                                                                                               "description": "position of the potentiometer",
                                                                                                      "mask": 65535,
                                                                                                 "max_value": 65535,
@@ -8982,7 +8982,7 @@
                                                                                                  } ],
                                                                           "momentary_positions": "none",
                                                                                       "outputs": [ {
-                                                                                                         "address": 4388,
+                                                                                                         "address": 4392,
                                                                                                      "description": "selector position",
                                                                                                             "mask": 32768,
                                                                                                        "max_value": 1,
@@ -9008,7 +9008,7 @@
                                                                                               "suggested_step": 3200
                                                                                           } ],
                                                                                "outputs": [ {
-                                                                                                  "address": 4400,
+                                                                                                  "address": 4398,
                                                                                               "description": "position of the potentiometer",
                                                                                                      "mask": 65535,
                                                                                                 "max_value": 65535,
@@ -9032,11 +9032,11 @@
                                                                                                  } ],
                                                                           "momentary_positions": "none",
                                                                                       "outputs": [ {
-                                                                                                         "address": 4392,
+                                                                                                         "address": 4390,
                                                                                                      "description": "selector position",
-                                                                                                            "mask": 24576,
+                                                                                                            "mask": 768,
                                                                                                        "max_value": 2,
-                                                                                                        "shift_by": 13,
+                                                                                                        "shift_by": 8,
                                                                                                           "suffix": "",
                                                                                                             "type": "integer"
                                                                                                  } ],
@@ -9057,11 +9057,11 @@
                                                                                                  } ],
                                                                           "momentary_positions": "none",
                                                                                       "outputs": [ {
-                                                                                                         "address": 4394,
+                                                                                                         "address": 4390,
                                                                                                      "description": "selector position",
-                                                                                                            "mask": 3,
+                                                                                                            "mask": 3072,
                                                                                                        "max_value": 2,
-                                                                                                        "shift_by": 0,
+                                                                                                        "shift_by": 10,
                                                                                                           "suffix": "",
                                                                                                             "type": "integer"
                                                                                                  } ],
@@ -9082,11 +9082,11 @@
                                                                                                  } ],
                                                                           "momentary_positions": "none",
                                                                                       "outputs": [ {
-                                                                                                         "address": 4394,
+                                                                                                         "address": 4390,
                                                                                                      "description": "selector position",
-                                                                                                            "mask": 12,
+                                                                                                            "mask": 12288,
                                                                                                        "max_value": 2,
-                                                                                                        "shift_by": 2,
+                                                                                                        "shift_by": 12,
                                                                                                           "suffix": "",
                                                                                                             "type": "integer"
                                                                                                  } ],
@@ -9107,11 +9107,11 @@
                                                                                                  } ],
                                                                           "momentary_positions": "none",
                                                                                       "outputs": [ {
-                                                                                                         "address": 4394,
+                                                                                                         "address": 4390,
                                                                                                      "description": "selector position",
-                                                                                                            "mask": 48,
+                                                                                                            "mask": 49152,
                                                                                                        "max_value": 2,
-                                                                                                        "shift_by": 4,
+                                                                                                        "shift_by": 14,
                                                                                                           "suffix": "",
                                                                                                             "type": "integer"
                                                                                                  } ],
@@ -9137,11 +9137,11 @@
                                                                                                  } ],
                                                                           "momentary_positions": "none",
                                                                                       "outputs": [ {
-                                                                                                         "address": 4392,
+                                                                                                         "address": 4394,
                                                                                                      "description": "selector position",
-                                                                                                            "mask": 32768,
+                                                                                                            "mask": 64,
                                                                                                        "max_value": 1,
-                                                                                                        "shift_by": 15,
+                                                                                                        "shift_by": 6,
                                                                                                           "suffix": "",
                                                                                                             "type": "integer"
                                                                                                  } ],
@@ -9164,15 +9164,15 @@
                                                                                      } ],
                                                               "momentary_positions": "none",
                                                                           "outputs": [ {
-                                                                                             "address": 4458,
+                                                                                             "address": 4456,
                                                                                          "description": "selector position",
-                                                                                                "mask": 30720,
+                                                                                                "mask": 1920,
                                                                                            "max_value": 9,
-                                                                                            "shift_by": 11,
+                                                                                            "shift_by": 7,
                                                                                               "suffix": "_INT",
                                                                                                 "type": "integer"
                                                                                      }, {
-                                                                                             "address": 4468,
+                                                                                             "address": 4466,
                                                                                          "description": "possible values: \"10\" \"15\" \"30\" \"35\" \"50\" \"55\" \"70\" \"75\" \"90\" \"95\" ",
                                                                                           "max_length": 2,
                                                                                               "suffix": "_STR",
@@ -9195,15 +9195,15 @@
                                                                                      } ],
                                                               "momentary_positions": "none",
                                                                           "outputs": [ {
-                                                                                             "address": 4458,
+                                                                                             "address": 4456,
                                                                                          "description": "selector position",
-                                                                                                "mask": 1536,
+                                                                                                "mask": 96,
                                                                                            "max_value": 3,
-                                                                                            "shift_by": 9,
+                                                                                            "shift_by": 5,
                                                                                               "suffix": "_INT",
                                                                                                 "type": "integer"
                                                                                      }, {
-                                                                                             "address": 4464,
+                                                                                             "address": 4462,
                                                                                          "description": "possible values: \"108\" \"109\" \"110\" \"111\" ",
                                                                                           "max_length": 3,
                                                                                               "suffix": "_STR",
@@ -9230,11 +9230,11 @@
                                                                                      } ],
                                                               "momentary_positions": "none",
                                                                           "outputs": [ {
-                                                                                             "address": 4458,
+                                                                                             "address": 4456,
                                                                                          "description": "selector position",
-                                                                                                "mask": 256,
+                                                                                                "mask": 16,
                                                                                            "max_value": 1,
-                                                                                            "shift_by": 8,
+                                                                                            "shift_by": 4,
                                                                                               "suffix": "",
                                                                                                 "type": "integer"
                                                                                      } ],
@@ -9256,7 +9256,7 @@
                                                                                   "suggested_step": 3200
                                                                               } ],
                                                                    "outputs": [ {
-                                                                                      "address": 4470,
+                                                                                      "address": 4468,
                                                                                   "description": "position of the potentiometer",
                                                                                          "mask": 65535,
                                                                                     "max_value": 65535,
@@ -9286,11 +9286,11 @@
                                                                                             } ],
                                                                      "momentary_positions": "none",
                                                                                  "outputs": [ {
-                                                                                                    "address": 4514,
+                                                                                                    "address": 4518,
                                                                                                 "description": "selector position",
-                                                                                                       "mask": 64,
+                                                                                                       "mask": 4,
                                                                                                   "max_value": 1,
-                                                                                                   "shift_by": 6,
+                                                                                                   "shift_by": 2,
                                                                                                      "suffix": "",
                                                                                                        "type": "integer"
                                                                                             } ],
@@ -9312,7 +9312,7 @@
                                                                                          "suggested_step": 3200
                                                                                      } ],
                                                                           "outputs": [ {
-                                                                                             "address": 4524,
+                                                                                             "address": 4522,
                                                                                          "description": "position of the potentiometer",
                                                                                                 "mask": 65535,
                                                                                            "max_value": 65535,
@@ -9341,11 +9341,11 @@
                                                                                             } ],
                                                                      "momentary_positions": "none",
                                                                                  "outputs": [ {
-                                                                                                    "address": 4514,
+                                                                                                    "address": 4518,
                                                                                                 "description": "selector position",
-                                                                                                       "mask": 16384,
+                                                                                                       "mask": 1024,
                                                                                                   "max_value": 1,
-                                                                                                   "shift_by": 14,
+                                                                                                   "shift_by": 10,
                                                                                                      "suffix": "",
                                                                                                        "type": "integer"
                                                                                             } ],
@@ -9370,11 +9370,11 @@
                                                                                             } ],
                                                                      "momentary_positions": "none",
                                                                                  "outputs": [ {
-                                                                                                    "address": 4514,
+                                                                                                    "address": 4508,
                                                                                                 "description": "selector position",
-                                                                                                       "mask": 8,
+                                                                                                       "mask": 32768,
                                                                                                   "max_value": 1,
-                                                                                                   "shift_by": 3,
+                                                                                                   "shift_by": 15,
                                                                                                      "suffix": "",
                                                                                                        "type": "integer"
                                                                                             } ],
@@ -9396,7 +9396,7 @@
                                                                                          "suggested_step": 3200
                                                                                      } ],
                                                                           "outputs": [ {
-                                                                                             "address": 4518,
+                                                                                             "address": 4514,
                                                                                          "description": "position of the potentiometer",
                                                                                                 "mask": 65535,
                                                                                            "max_value": 65535,
@@ -9424,11 +9424,11 @@
                                                                                             } ],
                                                                      "momentary_positions": "none",
                                                                                  "outputs": [ {
-                                                                                                    "address": 4514,
+                                                                                                    "address": 4518,
                                                                                                 "description": "selector position",
-                                                                                                       "mask": 1024,
+                                                                                                       "mask": 64,
                                                                                                   "max_value": 1,
-                                                                                                   "shift_by": 10,
+                                                                                                   "shift_by": 6,
                                                                                                      "suffix": "",
                                                                                                        "type": "integer"
                                                                                             } ],
@@ -9453,11 +9453,11 @@
                                                                                             } ],
                                                                      "momentary_positions": "none",
                                                                                  "outputs": [ {
-                                                                                                    "address": 4514,
+                                                                                                    "address": 4518,
                                                                                                 "description": "selector position",
-                                                                                                       "mask": 128,
+                                                                                                       "mask": 8,
                                                                                                   "max_value": 1,
-                                                                                                   "shift_by": 7,
+                                                                                                   "shift_by": 3,
                                                                                                      "suffix": "",
                                                                                                        "type": "integer"
                                                                                             } ],
@@ -9479,7 +9479,7 @@
                                                                                          "suggested_step": 3200
                                                                                      } ],
                                                                           "outputs": [ {
-                                                                                             "address": 4526,
+                                                                                             "address": 4524,
                                                                                          "description": "position of the potentiometer",
                                                                                                 "mask": 65535,
                                                                                            "max_value": 65535,
@@ -9507,11 +9507,11 @@
                                                                                             } ],
                                                                      "momentary_positions": "none",
                                                                                  "outputs": [ {
-                                                                                                    "address": 4514,
+                                                                                                    "address": 4518,
                                                                                                 "description": "selector position",
-                                                                                                       "mask": 256,
+                                                                                                       "mask": 16,
                                                                                                   "max_value": 1,
-                                                                                                   "shift_by": 8,
+                                                                                                   "shift_by": 4,
                                                                                                      "suffix": "",
                                                                                                        "type": "integer"
                                                                                             } ],
@@ -9533,7 +9533,7 @@
                                                                                          "suggested_step": 3200
                                                                                      } ],
                                                                           "outputs": [ {
-                                                                                             "address": 4528,
+                                                                                             "address": 4526,
                                                                                          "description": "position of the potentiometer",
                                                                                                 "mask": 65535,
                                                                                            "max_value": 65535,
@@ -9561,11 +9561,11 @@
                                                                                             } ],
                                                                      "momentary_positions": "none",
                                                                                  "outputs": [ {
-                                                                                                    "address": 4514,
+                                                                                                    "address": 4500,
                                                                                                 "description": "selector position",
-                                                                                                       "mask": 4,
+                                                                                                       "mask": 32768,
                                                                                                   "max_value": 1,
-                                                                                                   "shift_by": 2,
+                                                                                                   "shift_by": 15,
                                                                                                      "suffix": "",
                                                                                                        "type": "integer"
                                                                                             } ],
@@ -9587,7 +9587,7 @@
                                                                                          "suggested_step": 3200
                                                                                      } ],
                                                                           "outputs": [ {
-                                                                                             "address": 4516,
+                                                                                             "address": 4512,
                                                                                          "description": "position of the potentiometer",
                                                                                                 "mask": 65535,
                                                                                            "max_value": 65535,
@@ -9611,11 +9611,11 @@
                                                                                             } ],
                                                                      "momentary_positions": "none",
                                                                                  "outputs": [ {
-                                                                                                    "address": 4514,
+                                                                                                    "address": 4518,
                                                                                                 "description": "selector position",
-                                                                                                       "mask": 14336,
+                                                                                                       "mask": 896,
                                                                                                   "max_value": 4,
-                                                                                                   "shift_by": 11,
+                                                                                                   "shift_by": 7,
                                                                                                      "suffix": "",
                                                                                                        "type": "integer"
                                                                                             } ],
@@ -9640,11 +9640,11 @@
                                                                                             } ],
                                                                      "momentary_positions": "none",
                                                                                  "outputs": [ {
-                                                                                                    "address": 4514,
+                                                                                                    "address": 4518,
                                                                                                 "description": "selector position",
-                                                                                                       "mask": 512,
+                                                                                                       "mask": 32,
                                                                                                   "max_value": 1,
-                                                                                                   "shift_by": 9,
+                                                                                                   "shift_by": 5,
                                                                                                      "suffix": "",
                                                                                                        "type": "integer"
                                                                                             } ],
@@ -9666,7 +9666,7 @@
                                                                                          "suggested_step": 3200
                                                                                      } ],
                                                                           "outputs": [ {
-                                                                                             "address": 4530,
+                                                                                             "address": 4528,
                                                                                          "description": "position of the potentiometer",
                                                                                                 "mask": 65535,
                                                                                            "max_value": 65535,
@@ -9694,11 +9694,11 @@
                                                                                             } ],
                                                                      "momentary_positions": "none",
                                                                                  "outputs": [ {
-                                                                                                    "address": 4514,
+                                                                                                    "address": 4518,
                                                                                                 "description": "selector position",
-                                                                                                       "mask": 32,
+                                                                                                       "mask": 2,
                                                                                                   "max_value": 1,
-                                                                                                   "shift_by": 5,
+                                                                                                   "shift_by": 1,
                                                                                                      "suffix": "",
                                                                                                        "type": "integer"
                                                                                             } ],
@@ -9720,7 +9720,7 @@
                                                                                          "suggested_step": 3200
                                                                                      } ],
                                                                           "outputs": [ {
-                                                                                             "address": 4522,
+                                                                                             "address": 4520,
                                                                                          "description": "position of the potentiometer",
                                                                                                 "mask": 65535,
                                                                                            "max_value": 65535,
@@ -9748,11 +9748,11 @@
                                                                                             } ],
                                                                      "momentary_positions": "none",
                                                                                  "outputs": [ {
-                                                                                                    "address": 4514,
+                                                                                                    "address": 4518,
                                                                                                 "description": "selector position",
-                                                                                                       "mask": 16,
+                                                                                                       "mask": 1,
                                                                                                   "max_value": 1,
-                                                                                                   "shift_by": 4,
+                                                                                                   "shift_by": 0,
                                                                                                      "suffix": "",
                                                                                                        "type": "integer"
                                                                                             } ],
@@ -9774,7 +9774,7 @@
                                                                                          "suggested_step": 3200
                                                                                      } ],
                                                                           "outputs": [ {
-                                                                                             "address": 4520,
+                                                                                             "address": 4516,
                                                                                          "description": "position of the potentiometer",
                                                                                                 "mask": 65535,
                                                                                            "max_value": 65535,
@@ -9799,7 +9799,7 @@
                                                                                          "suggested_step": 3200
                                                                                      } ],
                                                                           "outputs": [ {
-                                                                                             "address": 4532,
+                                                                                             "address": 4530,
                                                                                          "description": "position of the potentiometer",
                                                                                                 "mask": 65535,
                                                                                            "max_value": 65535,
@@ -9825,7 +9825,7 @@
                                                                                              } ],
                                                                       "momentary_positions": "none",
                                                                                   "outputs": [ {
-                                                                                                     "address": 4362,
+                                                                                                     "address": 4360,
                                                                                                  "description": "selector position",
                                                                                                         "mask": 96,
                                                                                                    "max_value": 2,
@@ -9855,7 +9855,7 @@
                                                                                              } ],
                                                                       "momentary_positions": "none",
                                                                                   "outputs": [ {
-                                                                                                     "address": 4362,
+                                                                                                     "address": 4360,
                                                                                                  "description": "selector position",
                                                                                                         "mask": 128,
                                                                                                    "max_value": 1,
@@ -9876,7 +9876,7 @@
                                                                                             "max_value": 1
                                                                                       } ],
                                                                            "outputs": [ {
-                                                                                              "address": 4362,
+                                                                                              "address": 4360,
                                                                                           "description": "switch position -- 0 = off, 1 = on",
                                                                                                  "mask": 256,
                                                                                             "max_value": 1,
@@ -9904,7 +9904,7 @@
                                                                                              } ],
                                                                       "momentary_positions": "none",
                                                                                   "outputs": [ {
-                                                                                                     "address": 4362,
+                                                                                                     "address": 4360,
                                                                                                  "description": "selector position",
                                                                                                         "mask": 512,
                                                                                                    "max_value": 1,
@@ -9927,7 +9927,7 @@
                                                                                                 "max_value": 1
                                                                                           } ],
                                                                                "outputs": [ {
-                                                                                                  "address": 4370,
+                                                                                                  "address": 4368,
                                                                                               "description": "switch position -- 0 = off, 1 = on",
                                                                                                      "mask": 128,
                                                                                                 "max_value": 1,
@@ -9956,7 +9956,7 @@
                                                                                                  } ],
                                                                           "momentary_positions": "none",
                                                                                       "outputs": [ {
-                                                                                                         "address": 4370,
+                                                                                                         "address": 4368,
                                                                                                      "description": "selector position",
                                                                                                             "mask": 16,
                                                                                                        "max_value": 1,
@@ -9986,7 +9986,7 @@
                                                                                                  } ],
                                                                           "momentary_positions": "none",
                                                                                       "outputs": [ {
-                                                                                                         "address": 4362,
+                                                                                                         "address": 4360,
                                                                                                      "description": "selector position",
                                                                                                             "mask": 16,
                                                                                                        "max_value": 1,
@@ -10032,7 +10032,7 @@
                                                                                                  } ],
                                                                           "momentary_positions": "none",
                                                                                       "outputs": [ {
-                                                                                                         "address": 4340,
+                                                                                                         "address": 4338,
                                                                                                      "description": "selector position",
                                                                                                             "mask": 16,
                                                                                                        "max_value": 1,
@@ -10061,7 +10061,7 @@
                                                                                                  } ],
                                                                           "momentary_positions": "none",
                                                                                       "outputs": [ {
-                                                                                                         "address": 4370,
+                                                                                                         "address": 4368,
                                                                                                      "description": "selector position",
                                                                                                             "mask": 8,
                                                                                                        "max_value": 1,
@@ -10150,11 +10150,11 @@
                                                                                                  } ],
                                                                           "momentary_positions": "none",
                                                                                       "outputs": [ {
-                                                                                                         "address": 4436,
+                                                                                                         "address": 4420,
                                                                                                      "description": "selector position",
-                                                                                                            "mask": 3,
+                                                                                                            "mask": 6144,
                                                                                                        "max_value": 2,
-                                                                                                        "shift_by": 0,
+                                                                                                        "shift_by": 11,
                                                                                                           "suffix": "",
                                                                                                             "type": "integer"
                                                                                                  } ],
@@ -10182,7 +10182,7 @@
                                                                                       } ],
                                                                "momentary_positions": "none",
                                                                            "outputs": [ {
-                                                                                              "address": 4316,
+                                                                                              "address": 4314,
                                                                                           "description": "selector position",
                                                                                                  "mask": 2048,
                                                                                             "max_value": 1,
@@ -10212,7 +10212,7 @@
                                                                                       } ],
                                                                "momentary_positions": "none",
                                                                            "outputs": [ {
-                                                                                              "address": 4316,
+                                                                                              "address": 4314,
                                                                                           "description": "selector position",
                                                                                                  "mask": 4096,
                                                                                             "max_value": 1,
@@ -10242,7 +10242,7 @@
                                                                                       } ],
                                                                "momentary_positions": "none",
                                                                            "outputs": [ {
-                                                                                              "address": 4316,
+                                                                                              "address": 4314,
                                                                                           "description": "selector position",
                                                                                                  "mask": 8192,
                                                                                             "max_value": 1,
@@ -10272,7 +10272,7 @@
                                                                                       } ],
                                                                "momentary_positions": "none",
                                                                            "outputs": [ {
-                                                                                              "address": 4316,
+                                                                                              "address": 4314,
                                                                                           "description": "selector position",
                                                                                                  "mask": 16384,
                                                                                             "max_value": 1,
@@ -10302,7 +10302,7 @@
                                                                                       } ],
                                                                "momentary_positions": "none",
                                                                            "outputs": [ {
-                                                                                              "address": 4316,
+                                                                                              "address": 4314,
                                                                                           "description": "selector position",
                                                                                                  "mask": 32768,
                                                                                             "max_value": 1,
@@ -10332,7 +10332,7 @@
                                                                                       } ],
                                                                "momentary_positions": "none",
                                                                            "outputs": [ {
-                                                                                              "address": 4318,
+                                                                                              "address": 4316,
                                                                                           "description": "selector position",
                                                                                                  "mask": 1,
                                                                                             "max_value": 1,
@@ -10362,7 +10362,7 @@
                                                                                       } ],
                                                                "momentary_positions": "none",
                                                                            "outputs": [ {
-                                                                                              "address": 4318,
+                                                                                              "address": 4316,
                                                                                           "description": "selector position",
                                                                                                  "mask": 2,
                                                                                             "max_value": 1,
@@ -10392,7 +10392,7 @@
                                                                                       } ],
                                                                "momentary_positions": "none",
                                                                            "outputs": [ {
-                                                                                              "address": 4318,
+                                                                                              "address": 4316,
                                                                                           "description": "selector position",
                                                                                                  "mask": 4,
                                                                                             "max_value": 1,
@@ -10422,7 +10422,7 @@
                                                                                       } ],
                                                                "momentary_positions": "none",
                                                                            "outputs": [ {
-                                                                                              "address": 4318,
+                                                                                              "address": 4316,
                                                                                           "description": "selector position",
                                                                                                  "mask": 8,
                                                                                             "max_value": 1,
@@ -10452,7 +10452,7 @@
                                                                                       } ],
                                                                "momentary_positions": "none",
                                                                            "outputs": [ {
-                                                                                              "address": 4318,
+                                                                                              "address": 4316,
                                                                                           "description": "selector position",
                                                                                                  "mask": 16,
                                                                                             "max_value": 1,
@@ -10482,7 +10482,7 @@
                                                                                       } ],
                                                                "momentary_positions": "none",
                                                                            "outputs": [ {
-                                                                                              "address": 4318,
+                                                                                              "address": 4316,
                                                                                           "description": "selector position",
                                                                                                  "mask": 32,
                                                                                             "max_value": 1,
@@ -10512,7 +10512,7 @@
                                                                                       } ],
                                                                "momentary_positions": "none",
                                                                            "outputs": [ {
-                                                                                              "address": 4318,
+                                                                                              "address": 4316,
                                                                                           "description": "selector position",
                                                                                                  "mask": 64,
                                                                                             "max_value": 1,
@@ -10542,7 +10542,7 @@
                                                                                       } ],
                                                                "momentary_positions": "none",
                                                                            "outputs": [ {
-                                                                                              "address": 4318,
+                                                                                              "address": 4316,
                                                                                           "description": "selector position",
                                                                                                  "mask": 128,
                                                                                             "max_value": 1,
@@ -10572,7 +10572,7 @@
                                                                                       } ],
                                                                "momentary_positions": "none",
                                                                            "outputs": [ {
-                                                                                              "address": 4318,
+                                                                                              "address": 4316,
                                                                                           "description": "selector position",
                                                                                                  "mask": 256,
                                                                                             "max_value": 1,
@@ -10602,7 +10602,7 @@
                                                                                       } ],
                                                                "momentary_positions": "none",
                                                                            "outputs": [ {
-                                                                                              "address": 4318,
+                                                                                              "address": 4316,
                                                                                           "description": "selector position",
                                                                                                  "mask": 512,
                                                                                             "max_value": 1,
@@ -10632,7 +10632,7 @@
                                                                                       } ],
                                                                "momentary_positions": "none",
                                                                            "outputs": [ {
-                                                                                              "address": 4318,
+                                                                                              "address": 4316,
                                                                                           "description": "selector position",
                                                                                                  "mask": 1024,
                                                                                             "max_value": 1,
@@ -10662,7 +10662,7 @@
                                                                                       } ],
                                                                "momentary_positions": "none",
                                                                            "outputs": [ {
-                                                                                              "address": 4318,
+                                                                                              "address": 4316,
                                                                                           "description": "selector position",
                                                                                                  "mask": 2048,
                                                                                             "max_value": 1,
@@ -10692,7 +10692,7 @@
                                                                                       } ],
                                                                "momentary_positions": "none",
                                                                            "outputs": [ {
-                                                                                              "address": 4318,
+                                                                                              "address": 4316,
                                                                                           "description": "selector position",
                                                                                                  "mask": 4096,
                                                                                             "max_value": 1,
@@ -10722,7 +10722,7 @@
                                                                                       } ],
                                                                "momentary_positions": "none",
                                                                            "outputs": [ {
-                                                                                              "address": 4318,
+                                                                                              "address": 4316,
                                                                                           "description": "selector position",
                                                                                                  "mask": 8192,
                                                                                             "max_value": 1,
@@ -10752,7 +10752,7 @@
                                                                                       } ],
                                                                "momentary_positions": "none",
                                                                            "outputs": [ {
-                                                                                              "address": 4318,
+                                                                                              "address": 4316,
                                                                                           "description": "selector position",
                                                                                                  "mask": 16384,
                                                                                             "max_value": 1,
@@ -10774,7 +10774,7 @@
                                                                                       } ],
                                                                "momentary_positions": "first_and_last",
                                                                            "outputs": [ {
-                                                                                              "address": 4320,
+                                                                                              "address": 4318,
                                                                                           "description": "selector position",
                                                                                                  "mask": 3,
                                                                                             "max_value": 2,
@@ -10796,7 +10796,7 @@
                                                                                       } ],
                                                                "momentary_positions": "first_and_last",
                                                                            "outputs": [ {
-                                                                                              "address": 4320,
+                                                                                              "address": 4318,
                                                                                           "description": "selector position",
                                                                                                  "mask": 48,
                                                                                             "max_value": 2,
@@ -10818,7 +10818,7 @@
                                                                                       } ],
                                                                "momentary_positions": "first_and_last",
                                                                            "outputs": [ {
-                                                                                              "address": 4320,
+                                                                                              "address": 4318,
                                                                                           "description": "selector position",
                                                                                                  "mask": 192,
                                                                                             "max_value": 2,
@@ -10840,7 +10840,7 @@
                                                                                       } ],
                                                                "momentary_positions": "first_and_last",
                                                                            "outputs": [ {
-                                                                                              "address": 4320,
+                                                                                              "address": 4318,
                                                                                           "description": "selector position",
                                                                                                  "mask": 12,
                                                                                             "max_value": 2,
@@ -10865,7 +10865,7 @@
                                                                                       } ],
                                                                "momentary_positions": "none",
                                                                            "outputs": [ {
-                                                                                              "address": 4320,
+                                                                                              "address": 4318,
                                                                                           "description": "selector position",
                                                                                                  "mask": 3072,
                                                                                             "max_value": 2,
@@ -10887,7 +10887,7 @@
                                                                                       } ],
                                                                "momentary_positions": "first_and_last",
                                                                            "outputs": [ {
-                                                                                              "address": 4320,
+                                                                                              "address": 4318,
                                                                                           "description": "selector position",
                                                                                                  "mask": 768,
                                                                                             "max_value": 2,
@@ -10920,9 +10920,9 @@
                                                                                     "outputs": [ {
                                                                                                        "address": 4420,
                                                                                                    "description": "selector position",
-                                                                                                          "mask": 16384,
+                                                                                                          "mask": 1024,
                                                                                                      "max_value": 1,
-                                                                                                      "shift_by": 14,
+                                                                                                      "shift_by": 10,
                                                                                                         "suffix": "",
                                                                                                           "type": "integer"
                                                                                                } ],
@@ -10941,9 +10941,9 @@
                                                                              "outputs": [ {
                                                                                                 "address": 4420,
                                                                                             "description": "switch position -- 0 = off, 1 = on",
-                                                                                                   "mask": 2048,
+                                                                                                   "mask": 128,
                                                                                               "max_value": 1,
-                                                                                               "shift_by": 11,
+                                                                                               "shift_by": 7,
                                                                                                  "suffix": "",
                                                                                                    "type": "integer"
                                                                                         } ]
@@ -10964,7 +10964,7 @@
                                                                                             "suggested_step": 3200
                                                                                         } ],
                                                                              "outputs": [ {
-                                                                                                "address": 4430,
+                                                                                                "address": 4428,
                                                                                             "description": "position of the potentiometer",
                                                                                                    "mask": 65535,
                                                                                               "max_value": 65535,
@@ -10989,7 +10989,7 @@
                                                                                             "suggested_step": 3200
                                                                                         } ],
                                                                              "outputs": [ {
-                                                                                                "address": 4434,
+                                                                                                "address": 4432,
                                                                                             "description": "position of the potentiometer",
                                                                                                    "mask": 65535,
                                                                                               "max_value": 65535,
@@ -11014,7 +11014,7 @@
                                                                                             "suggested_step": 3200
                                                                                         } ],
                                                                              "outputs": [ {
-                                                                                                "address": 4426,
+                                                                                                "address": 4424,
                                                                                             "description": "position of the potentiometer",
                                                                                                    "mask": 65535,
                                                                                               "max_value": 65535,
@@ -11039,7 +11039,7 @@
                                                                                             "suggested_step": 3200
                                                                                         } ],
                                                                              "outputs": [ {
-                                                                                                "address": 4428,
+                                                                                                "address": 4426,
                                                                                             "description": "position of the potentiometer",
                                                                                                    "mask": 65535,
                                                                                               "max_value": 65535,
@@ -11064,7 +11064,7 @@
                                                                                             "suggested_step": 3200
                                                                                         } ],
                                                                              "outputs": [ {
-                                                                                                "address": 4432,
+                                                                                                "address": 4430,
                                                                                             "description": "position of the potentiometer",
                                                                                                    "mask": 65535,
                                                                                               "max_value": 65535,
@@ -11089,7 +11089,7 @@
                                                                                             "suggested_step": 3200
                                                                                         } ],
                                                                              "outputs": [ {
-                                                                                                "address": 4424,
+                                                                                                "address": 4422,
                                                                                             "description": "position of the potentiometer",
                                                                                                    "mask": 65535,
                                                                                               "max_value": 65535,
@@ -11119,9 +11119,9 @@
                                                                                     "outputs": [ {
                                                                                                        "address": 4420,
                                                                                                    "description": "selector position",
-                                                                                                          "mask": 4096,
+                                                                                                          "mask": 256,
                                                                                                      "max_value": 1,
-                                                                                                      "shift_by": 12,
+                                                                                                      "shift_by": 8,
                                                                                                         "suffix": "",
                                                                                                           "type": "integer"
                                                                                                } ],
@@ -11144,9 +11144,9 @@
                                                                                     "outputs": [ {
                                                                                                        "address": 4420,
                                                                                                    "description": "selector position",
-                                                                                                          "mask": 192,
+                                                                                                          "mask": 12,
                                                                                                      "max_value": 2,
-                                                                                                      "shift_by": 6,
+                                                                                                      "shift_by": 2,
                                                                                                         "suffix": "",
                                                                                                           "type": "integer"
                                                                                                } ],
@@ -11173,9 +11173,9 @@
                                                                                     "outputs": [ {
                                                                                                        "address": 4420,
                                                                                                    "description": "selector position",
-                                                                                                          "mask": 8192,
+                                                                                                          "mask": 512,
                                                                                                      "max_value": 1,
-                                                                                                      "shift_by": 13,
+                                                                                                      "shift_by": 9,
                                                                                                         "suffix": "",
                                                                                                           "type": "integer"
                                                                                                } ],
@@ -11202,11 +11202,11 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 4540,
+                                                                                                             "address": 4536,
                                                                                                          "description": "selector position",
-                                                                                                                "mask": 1,
+                                                                                                                "mask": 4096,
                                                                                                            "max_value": 1,
-                                                                                                            "shift_by": 0,
+                                                                                                            "shift_by": 12,
                                                                                                               "suffix": "",
                                                                                                                 "type": "integer"
                                                                                                      } ],
@@ -11231,11 +11231,11 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 4540,
+                                                                                                             "address": 4536,
                                                                                                          "description": "selector position",
-                                                                                                                "mask": 2,
+                                                                                                                "mask": 8192,
                                                                                                            "max_value": 1,
-                                                                                                            "shift_by": 1,
+                                                                                                            "shift_by": 13,
                                                                                                               "suffix": "",
                                                                                                                 "type": "integer"
                                                                                                      } ],
@@ -11260,11 +11260,11 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 4540,
+                                                                                                             "address": 4538,
                                                                                                          "description": "selector position",
-                                                                                                                "mask": 8192,
+                                                                                                                "mask": 512,
                                                                                                            "max_value": 1,
-                                                                                                            "shift_by": 13,
+                                                                                                            "shift_by": 9,
                                                                                                               "suffix": "",
                                                                                                                 "type": "integer"
                                                                                                      } ],
@@ -11289,11 +11289,11 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 4540,
+                                                                                                             "address": 4538,
                                                                                                          "description": "selector position",
-                                                                                                                "mask": 16384,
+                                                                                                                "mask": 1024,
                                                                                                            "max_value": 1,
-                                                                                                            "shift_by": 14,
+                                                                                                            "shift_by": 10,
                                                                                                               "suffix": "",
                                                                                                                 "type": "integer"
                                                                                                      } ],
@@ -11318,11 +11318,11 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 4540,
+                                                                                                             "address": 4538,
                                                                                                          "description": "selector position",
-                                                                                                                "mask": 32768,
+                                                                                                                "mask": 2048,
                                                                                                            "max_value": 1,
-                                                                                                            "shift_by": 15,
+                                                                                                            "shift_by": 11,
                                                                                                               "suffix": "",
                                                                                                                 "type": "integer"
                                                                                                      } ],
@@ -11343,31 +11343,15 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 4514,
+                                                                                                             "address": 4508,
                                                                                                          "description": "selector position",
-                                                                                                                "mask": 3,
+                                                                                                                "mask": 24576,
                                                                                                            "max_value": 2,
-                                                                                                            "shift_by": 0,
+                                                                                                            "shift_by": 13,
                                                                                                               "suffix": "",
                                                                                                                 "type": "integer"
                                                                                                      } ],
                                                                                  "physical_variant": "limited_rotary"
-                                                                          },
-                                                          "CANOPY_VALUE": {
-                                                                                  "category": "Misc",
-                                                                              "control_type": "analog_gauge",
-                                                                               "description": "Canopy Position",
-                                                                                "identifier": "CANOPY_VALUE",
-                                                                                    "inputs": [  ],
-                                                                                   "outputs": [ {
-                                                                                                      "address": 4308,
-                                                                                                  "description": "gauge position",
-                                                                                                         "mask": 65535,
-                                                                                                    "max_value": 65535,
-                                                                                                     "shift_by": 0,
-                                                                                                       "suffix": "",
-                                                                                                         "type": "integer"
-                                                                                              } ]
                                                                           },
                                                             "EMER_BRAKE": {
                                                                                          "category": "Misc",
@@ -11388,7 +11372,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 4508,
+                                                                                                             "address": 4494,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 32768,
                                                                                                            "max_value": 1,
@@ -11417,11 +11401,11 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 4384,
+                                                                                                             "address": 4378,
                                                                                                          "description": "selector position",
-                                                                                                                "mask": 16384,
+                                                                                                                "mask": 8192,
                                                                                                            "max_value": 1,
-                                                                                                            "shift_by": 14,
+                                                                                                            "shift_by": 13,
                                                                                                               "suffix": "",
                                                                                                                 "type": "integer"
                                                                                                      } ],
@@ -11446,11 +11430,11 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 4384,
+                                                                                                             "address": 4374,
                                                                                                          "description": "selector position",
-                                                                                                                "mask": 8192,
+                                                                                                                "mask": 32768,
                                                                                                            "max_value": 1,
-                                                                                                            "shift_by": 13,
+                                                                                                            "shift_by": 15,
                                                                                                               "suffix": "",
                                                                                                                 "type": "integer"
                                                                                                      } ],
@@ -11476,11 +11460,11 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 4540,
+                                                                                                             "address": 4538,
                                                                                                          "description": "selector position",
-                                                                                                                "mask": 16,
+                                                                                                                "mask": 1,
                                                                                                            "max_value": 1,
-                                                                                                            "shift_by": 4,
+                                                                                                            "shift_by": 0,
                                                                                                               "suffix": "",
                                                                                                                 "type": "integer"
                                                                                                      } ],
@@ -11505,11 +11489,11 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 4540,
+                                                                                                             "address": 4536,
                                                                                                          "description": "selector position",
-                                                                                                                "mask": 8,
+                                                                                                                "mask": 32768,
                                                                                                            "max_value": 1,
-                                                                                                            "shift_by": 3,
+                                                                                                            "shift_by": 15,
                                                                                                               "suffix": "",
                                                                                                                 "type": "integer"
                                                                                                      } ],
@@ -11527,11 +11511,11 @@
                                                                                                      } ],
                                                                               "momentary_positions": "first_and_last",
                                                                                           "outputs": [ {
-                                                                                                             "address": 4500,
+                                                                                                             "address": 4508,
                                                                                                          "description": "selector position",
-                                                                                                                "mask": 49152,
+                                                                                                                "mask": 6144,
                                                                                                            "max_value": 2,
-                                                                                                            "shift_by": 14,
+                                                                                                            "shift_by": 11,
                                                                                                               "suffix": "",
                                                                                                                 "type": "integer"
                                                                                                      } ],
@@ -11556,11 +11540,11 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 4540,
+                                                                                                             "address": 4536,
                                                                                                          "description": "selector position",
-                                                                                                                "mask": 4,
+                                                                                                                "mask": 16384,
                                                                                                            "max_value": 1,
-                                                                                                            "shift_by": 2,
+                                                                                                            "shift_by": 14,
                                                                                                               "suffix": "",
                                                                                                                 "type": "integer"
                                                                                                      } ],
@@ -11586,11 +11570,11 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 4540,
+                                                                                                             "address": 4538,
                                                                                                          "description": "selector position",
-                                                                                                                "mask": 4096,
+                                                                                                                "mask": 256,
                                                                                                            "max_value": 1,
-                                                                                                            "shift_by": 12,
+                                                                                                            "shift_by": 8,
                                                                                                               "suffix": "",
                                                                                                                 "type": "integer"
                                                                                                      } ],
@@ -11617,7 +11601,7 @@
                                                                                               } ],
                                                                        "momentary_positions": "none",
                                                                                    "outputs": [ {
-                                                                                                      "address": 4372,
+                                                                                                      "address": 4370,
                                                                                                   "description": "selector position",
                                                                                                          "mask": 64,
                                                                                                     "max_value": 1,
@@ -11647,7 +11631,7 @@
                                                                                               } ],
                                                                        "momentary_positions": "none",
                                                                                    "outputs": [ {
-                                                                                                      "address": 4372,
+                                                                                                      "address": 4370,
                                                                                                   "description": "selector position",
                                                                                                          "mask": 1,
                                                                                                     "max_value": 1,
@@ -11664,7 +11648,7 @@
                                                                          "identifier": "NMSP_ANCHR_LED",
                                                                              "inputs": [  ],
                                                                             "outputs": [ {
-                                                                                               "address": 4372,
+                                                                                               "address": 4370,
                                                                                            "description": "0 if light is off, 1 if light is on",
                                                                                                   "mask": 2,
                                                                                              "max_value": 1,
@@ -11693,7 +11677,7 @@
                                                                                               } ],
                                                                        "momentary_positions": "none",
                                                                                    "outputs": [ {
-                                                                                                      "address": 4370,
+                                                                                                      "address": 4368,
                                                                                                   "description": "selector position",
                                                                                                          "mask": 1024,
                                                                                                     "max_value": 1,
@@ -11710,7 +11694,7 @@
                                                                          "identifier": "NMSP_EGI_LED",
                                                                              "inputs": [  ],
                                                                             "outputs": [ {
-                                                                                               "address": 4370,
+                                                                                               "address": 4368,
                                                                                            "description": "0 if light is off, 1 if light is on",
                                                                                                   "mask": 2048,
                                                                                              "max_value": 1,
@@ -11726,11 +11710,11 @@
                                                                          "identifier": "NMSP_FM_LED",
                                                                              "inputs": [  ],
                                                                             "outputs": [ {
-                                                                                               "address": 4542,
+                                                                                               "address": 4540,
                                                                                            "description": "0 if light is off, 1 if light is on",
-                                                                                                  "mask": 64,
+                                                                                                  "mask": 4,
                                                                                              "max_value": 1,
-                                                                                              "shift_by": 6,
+                                                                                              "shift_by": 2,
                                                                                                 "suffix": "",
                                                                                                   "type": "integer"
                                                                                        } ]
@@ -11755,7 +11739,7 @@
                                                                                               } ],
                                                                        "momentary_positions": "none",
                                                                                    "outputs": [ {
-                                                                                                      "address": 4370,
+                                                                                                      "address": 4368,
                                                                                                   "description": "selector position",
                                                                                                          "mask": 256,
                                                                                                     "max_value": 1,
@@ -11772,7 +11756,7 @@
                                                                          "identifier": "NMSP_HARS_LED",
                                                                              "inputs": [  ],
                                                                             "outputs": [ {
-                                                                                               "address": 4370,
+                                                                                               "address": 4368,
                                                                                            "description": "0 if light is off, 1 if light is on",
                                                                                                   "mask": 512,
                                                                                              "max_value": 1,
@@ -11801,7 +11785,7 @@
                                                                                               } ],
                                                                        "momentary_positions": "none",
                                                                                    "outputs": [ {
-                                                                                                      "address": 4372,
+                                                                                                      "address": 4370,
                                                                                                   "description": "selector position",
                                                                                                          "mask": 16,
                                                                                                     "max_value": 1,
@@ -11818,7 +11802,7 @@
                                                                          "identifier": "NMSP_ILS_LED",
                                                                              "inputs": [  ],
                                                                             "outputs": [ {
-                                                                                               "address": 4372,
+                                                                                               "address": 4370,
                                                                                            "description": "0 if light is off, 1 if light is on",
                                                                                                   "mask": 32,
                                                                                              "max_value": 1,
@@ -11847,7 +11831,7 @@
                                                                                               } ],
                                                                        "momentary_positions": "none",
                                                                                    "outputs": [ {
-                                                                                                      "address": 4370,
+                                                                                                      "address": 4368,
                                                                                                   "description": "selector position",
                                                                                                          "mask": 16384,
                                                                                                     "max_value": 1,
@@ -11864,7 +11848,7 @@
                                                                          "identifier": "NMSP_STEERPT_LED",
                                                                              "inputs": [  ],
                                                                             "outputs": [ {
-                                                                                               "address": 4370,
+                                                                                               "address": 4368,
                                                                                            "description": "0 if light is off, 1 if light is on",
                                                                                                   "mask": 32768,
                                                                                              "max_value": 1,
@@ -11893,7 +11877,7 @@
                                                                                               } ],
                                                                        "momentary_positions": "none",
                                                                                    "outputs": [ {
-                                                                                                      "address": 4372,
+                                                                                                      "address": 4370,
                                                                                                   "description": "selector position",
                                                                                                          "mask": 4,
                                                                                                     "max_value": 1,
@@ -11910,7 +11894,7 @@
                                                                          "identifier": "NMSP_TCN_LED",
                                                                              "inputs": [  ],
                                                                             "outputs": [ {
-                                                                                               "address": 4372,
+                                                                                               "address": 4370,
                                                                                            "description": "0 if light is off, 1 if light is on",
                                                                                                   "mask": 8,
                                                                                              "max_value": 1,
@@ -11939,7 +11923,7 @@
                                                                                               } ],
                                                                        "momentary_positions": "none",
                                                                                    "outputs": [ {
-                                                                                                      "address": 4370,
+                                                                                                      "address": 4368,
                                                                                                   "description": "selector position",
                                                                                                          "mask": 4096,
                                                                                                     "max_value": 1,
@@ -11956,7 +11940,7 @@
                                                                          "identifier": "NMSP_TISL_LED",
                                                                              "inputs": [  ],
                                                                             "outputs": [ {
-                                                                                               "address": 4370,
+                                                                                               "address": 4368,
                                                                                            "description": "0 if light is off, 1 if light is on",
                                                                                                   "mask": 8192,
                                                                                              "max_value": 1,
@@ -11972,11 +11956,11 @@
                                                                          "identifier": "NMSP_UHF_LED",
                                                                              "inputs": [  ],
                                                                             "outputs": [ {
-                                                                                               "address": 4542,
+                                                                                               "address": 4540,
                                                                                            "description": "0 if light is off, 1 if light is on",
-                                                                                                  "mask": 32,
+                                                                                                  "mask": 2,
                                                                                              "max_value": 1,
-                                                                                              "shift_by": 5,
+                                                                                              "shift_by": 1,
                                                                                                 "suffix": "",
                                                                                                   "type": "integer"
                                                                                        } ]
@@ -12004,9 +11988,9 @@
                                                                                 "outputs": [ {
                                                                                                    "address": 4394,
                                                                                                "description": "selector position",
-                                                                                                      "mask": 32768,
+                                                                                                      "mask": 512,
                                                                                                  "max_value": 1,
-                                                                                                  "shift_by": 15,
+                                                                                                  "shift_by": 9,
                                                                                                     "suffix": "",
                                                                                                       "type": "integer"
                                                                                            } ],
@@ -12027,11 +12011,11 @@
                                                                                            } ],
                                                                     "momentary_positions": "none",
                                                                                 "outputs": [ {
-                                                                                                   "address": 4396,
+                                                                                                   "address": 4394,
                                                                                                "description": "selector position",
-                                                                                                      "mask": 12288,
+                                                                                                      "mask": 384,
                                                                                                  "max_value": 2,
-                                                                                                  "shift_by": 12,
+                                                                                                  "shift_by": 7,
                                                                                                     "suffix": "",
                                                                                                       "type": "integer"
                                                                                            } ],
@@ -12044,11 +12028,11 @@
                                                                       "identifier": "OXY_FLOW",
                                                                           "inputs": [  ],
                                                                          "outputs": [ {
-                                                                                            "address": 4396,
+                                                                                            "address": 4394,
                                                                                         "description": "0 if light is off, 1 if light is on",
-                                                                                               "mask": 32768,
+                                                                                               "mask": 2048,
                                                                                           "max_value": 1,
-                                                                                           "shift_by": 15,
+                                                                                           "shift_by": 11,
                                                                                              "suffix": "",
                                                                                                "type": "integer"
                                                                                     } ]
@@ -12060,7 +12044,7 @@
                                                                       "identifier": "OXY_PRESS",
                                                                           "inputs": [  ],
                                                                          "outputs": [ {
-                                                                                            "address": 4402,
+                                                                                            "address": 4400,
                                                                                         "description": "gauge position",
                                                                                                "mask": 65535,
                                                                                           "max_value": 65535,
@@ -12088,11 +12072,11 @@
                                                                                            } ],
                                                                     "momentary_positions": "none",
                                                                                 "outputs": [ {
-                                                                                                   "address": 4396,
+                                                                                                   "address": 4394,
                                                                                                "description": "selector position",
-                                                                                                      "mask": 16384,
+                                                                                                      "mask": 1024,
                                                                                                  "max_value": 1,
-                                                                                                  "shift_by": 14,
+                                                                                                  "shift_by": 10,
                                                                                                     "suffix": "",
                                                                                                       "type": "integer"
                                                                                            } ],
@@ -12116,7 +12100,7 @@
                                                                                   "suggested_step": 3200
                                                                               } ],
                                                                    "outputs": [ {
-                                                                                      "address": 4544,
+                                                                                      "address": 4542,
                                                                                   "description": "position of the potentiometer",
                                                                                          "mask": 65535,
                                                                                     "max_value": 65535,
@@ -12147,7 +12131,7 @@
                                                                                       } ],
                                                                "momentary_positions": "none",
                                                                            "outputs": [ {
-                                                                                              "address": 4318,
+                                                                                              "address": 4316,
                                                                                           "description": "selector position",
                                                                                                  "mask": 32768,
                                                                                             "max_value": 1,
@@ -12177,7 +12161,7 @@
                                                                                       } ],
                                                                "momentary_positions": "none",
                                                                            "outputs": [ {
-                                                                                              "address": 4320,
+                                                                                              "address": 4318,
                                                                                           "description": "selector position",
                                                                                                  "mask": 4096,
                                                                                             "max_value": 1,
@@ -12207,7 +12191,7 @@
                                                                                       } ],
                                                                "momentary_positions": "none",
                                                                            "outputs": [ {
-                                                                                              "address": 4320,
+                                                                                              "address": 4318,
                                                                                           "description": "selector position",
                                                                                                  "mask": 8192,
                                                                                             "max_value": 1,
@@ -12237,7 +12221,7 @@
                                                                                       } ],
                                                                "momentary_positions": "none",
                                                                            "outputs": [ {
-                                                                                              "address": 4320,
+                                                                                              "address": 4318,
                                                                                           "description": "selector position",
                                                                                                  "mask": 16384,
                                                                                             "max_value": 1,
@@ -12267,7 +12251,7 @@
                                                                                       } ],
                                                                "momentary_positions": "none",
                                                                            "outputs": [ {
-                                                                                              "address": 4320,
+                                                                                              "address": 4318,
                                                                                           "description": "selector position",
                                                                                                  "mask": 32768,
                                                                                             "max_value": 1,
@@ -12297,7 +12281,7 @@
                                                                                       } ],
                                                                "momentary_positions": "none",
                                                                            "outputs": [ {
-                                                                                              "address": 4322,
+                                                                                              "address": 4320,
                                                                                           "description": "selector position",
                                                                                                  "mask": 1,
                                                                                             "max_value": 1,
@@ -12327,7 +12311,7 @@
                                                                                       } ],
                                                                "momentary_positions": "none",
                                                                            "outputs": [ {
-                                                                                              "address": 4322,
+                                                                                              "address": 4320,
                                                                                           "description": "selector position",
                                                                                                  "mask": 2,
                                                                                             "max_value": 1,
@@ -12357,7 +12341,7 @@
                                                                                       } ],
                                                                "momentary_positions": "none",
                                                                            "outputs": [ {
-                                                                                              "address": 4322,
+                                                                                              "address": 4320,
                                                                                           "description": "selector position",
                                                                                                  "mask": 4,
                                                                                             "max_value": 1,
@@ -12387,7 +12371,7 @@
                                                                                       } ],
                                                                "momentary_positions": "none",
                                                                            "outputs": [ {
-                                                                                              "address": 4322,
+                                                                                              "address": 4320,
                                                                                           "description": "selector position",
                                                                                                  "mask": 8,
                                                                                             "max_value": 1,
@@ -12417,7 +12401,7 @@
                                                                                       } ],
                                                                "momentary_positions": "none",
                                                                            "outputs": [ {
-                                                                                              "address": 4322,
+                                                                                              "address": 4320,
                                                                                           "description": "selector position",
                                                                                                  "mask": 16,
                                                                                             "max_value": 1,
@@ -12447,7 +12431,7 @@
                                                                                       } ],
                                                                "momentary_positions": "none",
                                                                            "outputs": [ {
-                                                                                              "address": 4322,
+                                                                                              "address": 4320,
                                                                                           "description": "selector position",
                                                                                                  "mask": 32,
                                                                                             "max_value": 1,
@@ -12477,7 +12461,7 @@
                                                                                       } ],
                                                                "momentary_positions": "none",
                                                                            "outputs": [ {
-                                                                                              "address": 4322,
+                                                                                              "address": 4320,
                                                                                           "description": "selector position",
                                                                                                  "mask": 64,
                                                                                             "max_value": 1,
@@ -12507,7 +12491,7 @@
                                                                                       } ],
                                                                "momentary_positions": "none",
                                                                            "outputs": [ {
-                                                                                              "address": 4322,
+                                                                                              "address": 4320,
                                                                                           "description": "selector position",
                                                                                                  "mask": 128,
                                                                                             "max_value": 1,
@@ -12537,7 +12521,7 @@
                                                                                       } ],
                                                                "momentary_positions": "none",
                                                                            "outputs": [ {
-                                                                                              "address": 4322,
+                                                                                              "address": 4320,
                                                                                           "description": "selector position",
                                                                                                  "mask": 256,
                                                                                             "max_value": 1,
@@ -12567,7 +12551,7 @@
                                                                                       } ],
                                                                "momentary_positions": "none",
                                                                            "outputs": [ {
-                                                                                              "address": 4322,
+                                                                                              "address": 4320,
                                                                                           "description": "selector position",
                                                                                                  "mask": 512,
                                                                                             "max_value": 1,
@@ -12597,7 +12581,7 @@
                                                                                       } ],
                                                                "momentary_positions": "none",
                                                                            "outputs": [ {
-                                                                                              "address": 4322,
+                                                                                              "address": 4320,
                                                                                           "description": "selector position",
                                                                                                  "mask": 1024,
                                                                                             "max_value": 1,
@@ -12627,7 +12611,7 @@
                                                                                       } ],
                                                                "momentary_positions": "none",
                                                                            "outputs": [ {
-                                                                                              "address": 4322,
+                                                                                              "address": 4320,
                                                                                           "description": "selector position",
                                                                                                  "mask": 2048,
                                                                                             "max_value": 1,
@@ -12657,7 +12641,7 @@
                                                                                       } ],
                                                                "momentary_positions": "none",
                                                                            "outputs": [ {
-                                                                                              "address": 4322,
+                                                                                              "address": 4320,
                                                                                           "description": "selector position",
                                                                                                  "mask": 4096,
                                                                                             "max_value": 1,
@@ -12687,7 +12671,7 @@
                                                                                       } ],
                                                                "momentary_positions": "none",
                                                                            "outputs": [ {
-                                                                                              "address": 4322,
+                                                                                              "address": 4320,
                                                                                           "description": "selector position",
                                                                                                  "mask": 8192,
                                                                                             "max_value": 1,
@@ -12717,7 +12701,7 @@
                                                                                       } ],
                                                                "momentary_positions": "none",
                                                                            "outputs": [ {
-                                                                                              "address": 4322,
+                                                                                              "address": 4320,
                                                                                           "description": "selector position",
                                                                                                  "mask": 16384,
                                                                                             "max_value": 1,
@@ -12739,7 +12723,7 @@
                                                                                       } ],
                                                                "momentary_positions": "first_and_last",
                                                                            "outputs": [ {
-                                                                                              "address": 4324,
+                                                                                              "address": 4322,
                                                                                           "description": "selector position",
                                                                                                  "mask": 3,
                                                                                             "max_value": 2,
@@ -12761,7 +12745,7 @@
                                                                                       } ],
                                                                "momentary_positions": "first_and_last",
                                                                            "outputs": [ {
-                                                                                              "address": 4324,
+                                                                                              "address": 4322,
                                                                                           "description": "selector position",
                                                                                                  "mask": 48,
                                                                                             "max_value": 2,
@@ -12783,7 +12767,7 @@
                                                                                       } ],
                                                                "momentary_positions": "first_and_last",
                                                                            "outputs": [ {
-                                                                                              "address": 4324,
+                                                                                              "address": 4322,
                                                                                           "description": "selector position",
                                                                                                  "mask": 192,
                                                                                             "max_value": 2,
@@ -12805,7 +12789,7 @@
                                                                                       } ],
                                                                "momentary_positions": "first_and_last",
                                                                            "outputs": [ {
-                                                                                              "address": 4324,
+                                                                                              "address": 4322,
                                                                                           "description": "selector position",
                                                                                                  "mask": 12,
                                                                                             "max_value": 2,
@@ -12830,7 +12814,7 @@
                                                                                       } ],
                                                                "momentary_positions": "none",
                                                                            "outputs": [ {
-                                                                                              "address": 4324,
+                                                                                              "address": 4322,
                                                                                           "description": "selector position",
                                                                                                  "mask": 3072,
                                                                                             "max_value": 2,
@@ -12852,7 +12836,7 @@
                                                                                       } ],
                                                                "momentary_positions": "first_and_last",
                                                                            "outputs": [ {
-                                                                                              "address": 4324,
+                                                                                              "address": 4322,
                                                                                           "description": "selector position",
                                                                                                  "mask": 768,
                                                                                             "max_value": 2,
@@ -12879,7 +12863,7 @@
                                                                                                } ],
                                                                         "momentary_positions": "none",
                                                                                     "outputs": [ {
-                                                                                                       "address": 4362,
+                                                                                                       "address": 4360,
                                                                                                    "description": "selector position",
                                                                                                           "mask": 49152,
                                                                                                      "max_value": 2,
@@ -12900,7 +12884,7 @@
                                                                                               "max_value": 1
                                                                                         } ],
                                                                              "outputs": [ {
-                                                                                                "address": 4362,
+                                                                                                "address": 4360,
                                                                                             "description": "switch position -- 0 = off, 1 = on",
                                                                                                    "mask": 4096,
                                                                                               "max_value": 1,
@@ -12920,7 +12904,7 @@
                                                                                               "max_value": 1
                                                                                         } ],
                                                                              "outputs": [ {
-                                                                                                "address": 4362,
+                                                                                                "address": 4360,
                                                                                             "description": "switch position -- 0 = off, 1 = on",
                                                                                                    "mask": 8192,
                                                                                               "max_value": 1,
@@ -12949,7 +12933,7 @@
                                                                                                } ],
                                                                         "momentary_positions": "none",
                                                                                     "outputs": [ {
-                                                                                                       "address": 4366,
+                                                                                                       "address": 4364,
                                                                                                    "description": "selector position",
                                                                                                           "mask": 1,
                                                                                                      "max_value": 1,
@@ -12970,7 +12954,7 @@
                                                                                               "max_value": 1
                                                                                         } ],
                                                                              "outputs": [ {
-                                                                                                "address": 4362,
+                                                                                                "address": 4360,
                                                                                             "description": "switch position -- 0 = off, 1 = on",
                                                                                                    "mask": 1024,
                                                                                               "max_value": 1,
@@ -12990,7 +12974,7 @@
                                                                                               "max_value": 1
                                                                                         } ],
                                                                              "outputs": [ {
-                                                                                                "address": 4362,
+                                                                                                "address": 4360,
                                                                                             "description": "switch position -- 0 = off, 1 = on",
                                                                                                    "mask": 2048,
                                                                                               "max_value": 1,
@@ -13015,7 +12999,7 @@
                                                                                             "suggested_step": 3200
                                                                                         } ],
                                                                              "outputs": [ {
-                                                                                                "address": 4368,
+                                                                                                "address": 4366,
                                                                                             "description": "position of the potentiometer",
                                                                                                    "mask": 65535,
                                                                                               "max_value": 65535,
@@ -13057,11 +13041,11 @@
                                                                                                 } ],
                                                                          "momentary_positions": "none",
                                                                                      "outputs": [ {
-                                                                                                        "address": 4534,
+                                                                                                        "address": 4536,
                                                                                                     "description": "selector position",
-                                                                                                           "mask": 7168,
+                                                                                                           "mask": 448,
                                                                                                       "max_value": 5,
-                                                                                                       "shift_by": 10,
+                                                                                                       "shift_by": 6,
                                                                                                          "suffix": "",
                                                                                                            "type": "integer"
                                                                                                 } ],
@@ -13086,11 +13070,11 @@
                                                                                                 } ],
                                                                          "momentary_positions": "none",
                                                                                      "outputs": [ {
-                                                                                                        "address": 4534,
+                                                                                                        "address": 4536,
                                                                                                     "description": "selector position",
-                                                                                                           "mask": 128,
+                                                                                                           "mask": 8,
                                                                                                       "max_value": 1,
-                                                                                                       "shift_by": 7,
+                                                                                                       "shift_by": 3,
                                                                                                          "suffix": "",
                                                                                                            "type": "integer"
                                                                                                 } ],
@@ -13111,11 +13095,11 @@
                                                                                                 } ],
                                                                          "momentary_positions": "none",
                                                                                      "outputs": [ {
-                                                                                                        "address": 4534,
+                                                                                                        "address": 4536,
                                                                                                     "description": "selector position",
-                                                                                                           "mask": 24576,
+                                                                                                           "mask": 1536,
                                                                                                       "max_value": 2,
-                                                                                                       "shift_by": 13,
+                                                                                                       "shift_by": 9,
                                                                                                          "suffix": "",
                                                                                                            "type": "integer"
                                                                                                 } ],
@@ -13136,11 +13120,11 @@
                                                                                                 } ],
                                                                          "momentary_positions": "none",
                                                                                      "outputs": [ {
-                                                                                                        "address": 4534,
+                                                                                                        "address": 4536,
                                                                                                     "description": "selector position",
-                                                                                                           "mask": 768,
+                                                                                                           "mask": 48,
                                                                                                       "max_value": 2,
-                                                                                                       "shift_by": 8,
+                                                                                                       "shift_by": 4,
                                                                                                          "suffix": "",
                                                                                                            "type": "integer"
                                                                                                 } ],
@@ -13165,11 +13149,11 @@
                                                                                                 } ],
                                                                          "momentary_positions": "none",
                                                                                      "outputs": [ {
-                                                                                                        "address": 4534,
+                                                                                                        "address": 4536,
                                                                                                     "description": "selector position",
-                                                                                                           "mask": 32768,
+                                                                                                           "mask": 2048,
                                                                                                       "max_value": 1,
-                                                                                                       "shift_by": 15,
+                                                                                                       "shift_by": 11,
                                                                                                          "suffix": "",
                                                                                                            "type": "integer"
                                                                                                 } ],
@@ -13194,11 +13178,11 @@
                                                                                                 } ],
                                                                          "momentary_positions": "none",
                                                                                      "outputs": [ {
-                                                                                                        "address": 4534,
+                                                                                                        "address": 4536,
                                                                                                     "description": "selector position",
-                                                                                                           "mask": 64,
+                                                                                                           "mask": 4,
                                                                                                       "max_value": 1,
-                                                                                                       "shift_by": 6,
+                                                                                                       "shift_by": 2,
                                                                                                          "suffix": "",
                                                                                                            "type": "integer"
                                                                                                 } ],
@@ -13223,11 +13207,11 @@
                                                                                                 } ],
                                                                          "momentary_positions": "none",
                                                                                      "outputs": [ {
-                                                                                                        "address": 4534,
+                                                                                                        "address": 4536,
                                                                                                     "description": "selector position",
-                                                                                                           "mask": 32,
+                                                                                                           "mask": 2,
                                                                                                       "max_value": 1,
-                                                                                                       "shift_by": 5,
+                                                                                                       "shift_by": 1,
                                                                                                          "suffix": "",
                                                                                                            "type": "integer"
                                                                                                 } ],
@@ -13251,7 +13235,7 @@
                                                                                          "suggested_step": 3200
                                                                                      } ],
                                                                           "outputs": [ {
-                                                                                             "address": 4462,
+                                                                                             "address": 4460,
                                                                                          "description": "position of the potentiometer",
                                                                                                 "mask": 65535,
                                                                                            "max_value": 65535,
@@ -13276,7 +13260,7 @@
                                                                                          "suggested_step": 3200
                                                                                      } ],
                                                                           "outputs": [ {
-                                                                                             "address": 4460,
+                                                                                             "address": 4458,
                                                                                          "description": "position of the potentiometer",
                                                                                                 "mask": 65535,
                                                                                            "max_value": 65535,
@@ -13323,11 +13307,11 @@
                                                                                               } ],
                                                                        "momentary_positions": "none",
                                                                                    "outputs": [ {
-                                                                                                      "address": 4436,
+                                                                                                      "address": 4440,
                                                                                                   "description": "selector position",
-                                                                                                         "mask": 1024,
+                                                                                                         "mask": 64,
                                                                                                     "max_value": 1,
-                                                                                                     "shift_by": 10,
+                                                                                                     "shift_by": 6,
                                                                                                        "suffix": "",
                                                                                                          "type": "integer"
                                                                                               } ],
@@ -13394,7 +13378,7 @@
                                                                                            "suggested_step": 3200
                                                                                        } ],
                                                                             "outputs": [ {
-                                                                                               "address": 4450,
+                                                                                               "address": 4448,
                                                                                            "description": "the rotation of the knob in the cockpit (not the value that is controlled by this knob!)",
                                                                                                   "mask": 65535,
                                                                                              "max_value": 65535,
@@ -13428,7 +13412,7 @@
                                                                       "identifier": "COMPASS_BANK",
                                                                           "inputs": [  ],
                                                                          "outputs": [ {
-                                                                                            "address": 4808,
+                                                                                            "address": 4806,
                                                                                         "description": "gauge position",
                                                                                                "mask": 65535,
                                                                                           "max_value": 65535,
@@ -13444,7 +13428,7 @@
                                                                       "identifier": "COMPASS_HDG",
                                                                           "inputs": [  ],
                                                                          "outputs": [ {
-                                                                                            "address": 4804,
+                                                                                            "address": 4802,
                                                                                         "description": "gauge position",
                                                                                                "mask": 65535,
                                                                                           "max_value": 65535,
@@ -13460,7 +13444,7 @@
                                                                       "identifier": "COMPASS_PITCH",
                                                                           "inputs": [  ],
                                                                          "outputs": [ {
-                                                                                            "address": 4806,
+                                                                                            "address": 4804,
                                                                                         "description": "gauge position",
                                                                                                "mask": 65535,
                                                                                           "max_value": 65535,
@@ -13486,11 +13470,11 @@
                                                                                             } ],
                                                                      "momentary_positions": "none",
                                                                                  "outputs": [ {
-                                                                                                    "address": 4458,
+                                                                                                    "address": 4440,
                                                                                                 "description": "selector position",
-                                                                                                       "mask": 15,
+                                                                                                       "mask": 61440,
                                                                                                   "max_value": 10,
-                                                                                                   "shift_by": 0,
+                                                                                                   "shift_by": 12,
                                                                                                      "suffix": "",
                                                                                                        "type": "integer"
                                                                                             } ],
@@ -13507,11 +13491,11 @@
                                                                                             } ],
                                                                      "momentary_positions": "none",
                                                                                  "outputs": [ {
-                                                                                                    "address": 4436,
+                                                                                                    "address": 4440,
                                                                                                 "description": "selector position",
-                                                                                                       "mask": 61440,
+                                                                                                       "mask": 3840,
                                                                                                   "max_value": 10,
-                                                                                                   "shift_by": 12,
+                                                                                                   "shift_by": 8,
                                                                                                      "suffix": "",
                                                                                                        "type": "integer"
                                                                                             } ],
@@ -13524,7 +13508,7 @@
                                                                        "identifier": "TACAN_CHANNEL",
                                                                            "inputs": [  ],
                                                                           "outputs": [ {
-                                                                                             "address": 4452,
+                                                                                             "address": 4450,
                                                                                          "description": "TACAN Channel",
                                                                                           "max_length": 4,
                                                                                               "suffix": "",
@@ -13546,11 +13530,11 @@
                                                                                             } ],
                                                                      "momentary_positions": "none",
                                                                                  "outputs": [ {
-                                                                                                    "address": 4458,
+                                                                                                    "address": 4456,
                                                                                                 "description": "selector position",
-                                                                                                       "mask": 224,
+                                                                                                       "mask": 14,
                                                                                                   "max_value": 4,
-                                                                                                   "shift_by": 5,
+                                                                                                   "shift_by": 1,
                                                                                                      "suffix": "",
                                                                                                        "type": "integer"
                                                                                             } ],
@@ -13563,7 +13547,7 @@
                                                                        "identifier": "TACAN_TEST",
                                                                            "inputs": [  ],
                                                                           "outputs": [ {
-                                                                                             "address": 4316,
+                                                                                             "address": 4314,
                                                                                          "description": "0 if light is off, 1 if light is on",
                                                                                                 "mask": 1024,
                                                                                            "max_value": 1,
@@ -13592,11 +13576,11 @@
                                                                                             } ],
                                                                      "momentary_positions": "none",
                                                                                  "outputs": [ {
-                                                                                                    "address": 4436,
+                                                                                                    "address": 4440,
                                                                                                 "description": "selector position",
-                                                                                                       "mask": 2048,
+                                                                                                       "mask": 128,
                                                                                                   "max_value": 1,
-                                                                                                   "shift_by": 11,
+                                                                                                   "shift_by": 7,
                                                                                                      "suffix": "",
                                                                                                        "type": "integer"
                                                                                             } ],
@@ -13618,7 +13602,7 @@
                                                                                          "suggested_step": 3200
                                                                                      } ],
                                                                           "outputs": [ {
-                                                                                             "address": 4456,
+                                                                                             "address": 4454,
                                                                                          "description": "position of the potentiometer",
                                                                                                 "mask": 65535,
                                                                                            "max_value": 65535,
@@ -13646,11 +13630,11 @@
                                                                                             } ],
                                                                      "momentary_positions": "none",
                                                                                  "outputs": [ {
-                                                                                                    "address": 4458,
+                                                                                                    "address": 4456,
                                                                                                 "description": "selector position",
-                                                                                                       "mask": 16,
+                                                                                                       "mask": 1,
                                                                                                   "max_value": 1,
-                                                                                                   "shift_by": 4,
+                                                                                                   "shift_by": 0,
                                                                                                      "suffix": "",
                                                                                                        "type": "integer"
                                                                                             } ],
@@ -13673,7 +13657,7 @@
                                                                                               } ],
                                                                        "momentary_positions": "none",
                                                                                    "outputs": [ {
-                                                                                                      "address": 4374,
+                                                                                                      "address": 4372,
                                                                                                   "description": "selector position",
                                                                                                          "mask": 3840,
                                                                                                     "max_value": 9,
@@ -13681,7 +13665,7 @@
                                                                                                        "suffix": "_INT",
                                                                                                          "type": "integer"
                                                                                               }, {
-                                                                                                      "address": 4376,
+                                                                                                      "address": 4374,
                                                                                                   "description": "possible values: \"0\" \"1\" \"2\" \"3\" \"4\" \"5\" \"6\" \"7\" \"8\" \"9\" \"0\" ",
                                                                                                    "max_length": 1,
                                                                                                        "suffix": "_STR",
@@ -13704,7 +13688,7 @@
                                                                                               } ],
                                                                        "momentary_positions": "none",
                                                                                    "outputs": [ {
-                                                                                                      "address": 4372,
+                                                                                                      "address": 4370,
                                                                                                   "description": "selector position",
                                                                                                          "mask": 61440,
                                                                                                     "max_value": 9,
@@ -13712,7 +13696,7 @@
                                                                                                        "suffix": "_INT",
                                                                                                          "type": "integer"
                                                                                               }, {
-                                                                                                      "address": 4374,
+                                                                                                      "address": 4372,
                                                                                                   "description": "possible values: \"0\" \"1\" \"2\" \"3\" \"4\" \"5\" \"6\" \"7\" \"8\" \"9\" \"0\" ",
                                                                                                    "max_length": 1,
                                                                                                        "suffix": "_STR",
@@ -13735,7 +13719,7 @@
                                                                                               } ],
                                                                        "momentary_positions": "none",
                                                                                    "outputs": [ {
-                                                                                                      "address": 4374,
+                                                                                                      "address": 4372,
                                                                                                   "description": "selector position",
                                                                                                          "mask": 12288,
                                                                                                     "max_value": 2,
@@ -13765,7 +13749,7 @@
                                                                                               } ],
                                                                        "momentary_positions": "none",
                                                                                    "outputs": [ {
-                                                                                                      "address": 4374,
+                                                                                                      "address": 4372,
                                                                                                   "description": "selector position",
                                                                                                          "mask": 32768,
                                                                                                     "max_value": 1,
@@ -13774,22 +13758,6 @@
                                                                                                          "type": "integer"
                                                                                               } ],
                                                                           "physical_variant": "push_button"
-                                                                   },
-                                                    "TISL_BITE_L": {
-                                                                           "category": "TISL Panel",
-                                                                       "control_type": "led",
-                                                                        "description": "TISL BITE Light",
-                                                                         "identifier": "TISL_BITE_L",
-                                                                             "inputs": [  ],
-                                                                            "outputs": [ {
-                                                                                               "address": 4376,
-                                                                                           "description": "0 if light is off, 1 if light is on",
-                                                                                                  "mask": 32768,
-                                                                                             "max_value": 1,
-                                                                                              "shift_by": 15,
-                                                                                                "suffix": "",
-                                                                                                  "type": "integer"
-                                                                                       } ]
                                                                    },
                                                      "TISL_CODE1": {
                                                                                   "category": "TISL Panel",
@@ -13806,7 +13774,7 @@
                                                                                               } ],
                                                                        "momentary_positions": "none",
                                                                                    "outputs": [ {
-                                                                                                      "address": 4376,
+                                                                                                      "address": 4374,
                                                                                                   "description": "selector position",
                                                                                                          "mask": 7936,
                                                                                                     "max_value": 19,
@@ -13814,7 +13782,7 @@
                                                                                                        "suffix": "_INT",
                                                                                                          "type": "integer"
                                                                                               }, {
-                                                                                                      "address": 4378,
+                                                                                                      "address": 4376,
                                                                                                   "description": "possible values: \"0\" \"0.5\" \"1\" \"1.5\" \"2\" \"2.5\" \"3\" \"3.5\" \"4\" \"4.5\" \"5\" \"5.5\" \"6\" \"6.5\" \"7\" \"7.5\" \"8\" \"8.5\" \"9\" \"9.5\" \"0\" ",
                                                                                                    "max_length": 3,
                                                                                                        "suffix": "_STR",
@@ -13837,7 +13805,7 @@
                                                                                               } ],
                                                                        "momentary_positions": "none",
                                                                                    "outputs": [ {
-                                                                                                      "address": 4380,
+                                                                                                      "address": 4378,
                                                                                                   "description": "selector position",
                                                                                                          "mask": 7936,
                                                                                                     "max_value": 19,
@@ -13845,7 +13813,7 @@
                                                                                                        "suffix": "_INT",
                                                                                                          "type": "integer"
                                                                                               }, {
-                                                                                                      "address": 4382,
+                                                                                                      "address": 4380,
                                                                                                   "description": "possible values: \"0\" \"0.5\" \"1\" \"1.5\" \"2\" \"2.5\" \"3\" \"3.5\" \"4\" \"4.5\" \"5\" \"5.5\" \"6\" \"6.5\" \"7\" \"7.5\" \"8\" \"8.5\" \"9\" \"9.5\" \"0\" ",
                                                                                                    "max_length": 3,
                                                                                                        "suffix": "_STR",
@@ -13868,7 +13836,7 @@
                                                                                               } ],
                                                                        "momentary_positions": "none",
                                                                                    "outputs": [ {
-                                                                                                      "address": 4384,
+                                                                                                      "address": 4382,
                                                                                                   "description": "selector position",
                                                                                                          "mask": 7936,
                                                                                                     "max_value": 19,
@@ -13876,7 +13844,7 @@
                                                                                                        "suffix": "_INT",
                                                                                                          "type": "integer"
                                                                                               }, {
-                                                                                                      "address": 4386,
+                                                                                                      "address": 4384,
                                                                                                   "description": "possible values: \"0\" \"0.5\" \"1\" \"1.5\" \"2\" \"2.5\" \"3\" \"3.5\" \"4\" \"4.5\" \"5\" \"5.5\" \"6\" \"6.5\" \"7\" \"7.5\" \"8\" \"8.5\" \"9\" \"9.5\" \"0\" ",
                                                                                                    "max_length": 3,
                                                                                                        "suffix": "_STR",
@@ -13899,7 +13867,7 @@
                                                                                               } ],
                                                                        "momentary_positions": "none",
                                                                                    "outputs": [ {
-                                                                                                      "address": 4388,
+                                                                                                      "address": 4386,
                                                                                                   "description": "selector position",
                                                                                                          "mask": 7936,
                                                                                                     "max_value": 19,
@@ -13907,7 +13875,7 @@
                                                                                                        "suffix": "_INT",
                                                                                                          "type": "integer"
                                                                                               }, {
-                                                                                                      "address": 4390,
+                                                                                                      "address": 4388,
                                                                                                   "description": "possible values: \"0\" \"0.5\" \"1\" \"1.5\" \"2\" \"2.5\" \"3\" \"3.5\" \"4\" \"4.5\" \"5\" \"5.5\" \"6\" \"6.5\" \"7\" \"7.5\" \"8\" \"8.5\" \"9\" \"9.5\" \"0\" ",
                                                                                                    "max_length": 3,
                                                                                                        "suffix": "_STR",
@@ -13935,7 +13903,7 @@
                                                                                               } ],
                                                                        "momentary_positions": "none",
                                                                                    "outputs": [ {
-                                                                                                      "address": 4374,
+                                                                                                      "address": 4372,
                                                                                                   "description": "selector position",
                                                                                                          "mask": 16384,
                                                                                                     "max_value": 1,
@@ -13944,22 +13912,6 @@
                                                                                                          "type": "integer"
                                                                                               } ],
                                                                           "physical_variant": "push_button"
-                                                                   },
-                                                   "TISL_ENTER_L": {
-                                                                           "category": "TISL Panel",
-                                                                       "control_type": "led",
-                                                                        "description": "TISL ENTER Light",
-                                                                         "identifier": "TISL_ENTER_L",
-                                                                             "inputs": [  ],
-                                                                            "outputs": [ {
-                                                                                               "address": 4376,
-                                                                                           "description": "0 if light is off, 1 if light is on",
-                                                                                                  "mask": 8192,
-                                                                                             "max_value": 1,
-                                                                                              "shift_by": 13,
-                                                                                                "suffix": "",
-                                                                                                  "type": "integer"
-                                                                                       } ]
                                                                    },
                                                       "TISL_MODE": {
                                                                                   "category": "TISL Panel",
@@ -13976,7 +13928,7 @@
                                                                                               } ],
                                                                        "momentary_positions": "none",
                                                                                    "outputs": [ {
-                                                                                                      "address": 4372,
+                                                                                                      "address": 4370,
                                                                                                   "description": "selector position",
                                                                                                          "mask": 896,
                                                                                                     "max_value": 4,
@@ -13985,22 +13937,6 @@
                                                                                                          "type": "integer"
                                                                                               } ],
                                                                           "physical_variant": "limited_rotary"
-                                                                   },
-                                                "TISL_OVERTEMP_L": {
-                                                                           "category": "TISL Panel",
-                                                                       "control_type": "led",
-                                                                        "description": "TISL OVER TEMP Light",
-                                                                         "identifier": "TISL_OVERTEMP_L",
-                                                                             "inputs": [  ],
-                                                                            "outputs": [ {
-                                                                                               "address": 4376,
-                                                                                           "description": "0 if light is off, 1 if light is on",
-                                                                                                  "mask": 16384,
-                                                                                             "max_value": 1,
-                                                                                              "shift_by": 14,
-                                                                                                "suffix": "",
-                                                                                                  "type": "integer"
-                                                                                       } ]
                                                                    },
                                                "TISL_SLANT_RANGE": {
                                                                                   "category": "TISL Panel",
@@ -14017,7 +13953,7 @@
                                                                                               } ],
                                                                        "momentary_positions": "none",
                                                                                    "outputs": [ {
-                                                                                                      "address": 4372,
+                                                                                                      "address": 4370,
                                                                                                   "description": "selector position",
                                                                                                          "mask": 3072,
                                                                                                     "max_value": 2,
@@ -14026,22 +13962,6 @@
                                                                                                          "type": "integer"
                                                                                               } ],
                                                                           "physical_variant": "limited_rotary"
-                                                                   },
-                                                   "TISL_TRACK_L": {
-                                                                           "category": "TISL Panel",
-                                                                       "control_type": "led",
-                                                                        "description": "TISL TRACK Light",
-                                                                         "identifier": "TISL_TRACK_L",
-                                                                             "inputs": [  ],
-                                                                            "outputs": [ {
-                                                                                               "address": 4380,
-                                                                                           "description": "0 if light is off, 1 if light is on",
-                                                                                                  "mask": 8192,
-                                                                                             "max_value": 1,
-                                                                                              "shift_by": 13,
-                                                                                                "suffix": "",
-                                                                                                  "type": "integer"
-                                                                                       } ]
                                                                    }
                                            },
                                "Throttle": {
@@ -14064,7 +13984,7 @@
                                                                                                       } ],
                                                                                "momentary_positions": "none",
                                                                                            "outputs": [ {
-                                                                                                              "address": 4360,
+                                                                                                              "address": 4358,
                                                                                                           "description": "selector position",
                                                                                                                  "mask": 32768,
                                                                                                             "max_value": 1,
@@ -14093,7 +14013,7 @@
                                                                                                       } ],
                                                                                "momentary_positions": "none",
                                                                                            "outputs": [ {
-                                                                                                              "address": 4360,
+                                                                                                              "address": 4358,
                                                                                                           "description": "selector position",
                                                                                                                  "mask": 8192,
                                                                                                             "max_value": 1,
@@ -14122,7 +14042,7 @@
                                                                                                       } ],
                                                                                "momentary_positions": "none",
                                                                                            "outputs": [ {
-                                                                                                              "address": 4360,
+                                                                                                              "address": 4358,
                                                                                                           "description": "selector position",
                                                                                                                  "mask": 16384,
                                                                                                             "max_value": 1,
@@ -14144,7 +14064,7 @@
                                                                                                       } ],
                                                                                "momentary_positions": "first_and_last",
                                                                                            "outputs": [ {
-                                                                                                              "address": 4362,
+                                                                                                              "address": 4360,
                                                                                                           "description": "selector position",
                                                                                                                  "mask": 3,
                                                                                                             "max_value": 2,
@@ -14166,7 +14086,7 @@
                                                                                                       } ],
                                                                                "momentary_positions": "first_and_last",
                                                                                            "outputs": [ {
-                                                                                                              "address": 4362,
+                                                                                                              "address": 4360,
                                                                                                           "description": "selector position",
                                                                                                                  "mask": 12,
                                                                                                             "max_value": 2,
@@ -14192,7 +14112,7 @@
                                                                                                    "suggested_step": 3200
                                                                                                } ],
                                                                                     "outputs": [ {
-                                                                                                       "address": 4364,
+                                                                                                       "address": 4362,
                                                                                                    "description": "position of the potentiometer",
                                                                                                           "mask": 65535,
                                                                                                      "max_value": 65535,
@@ -14216,7 +14136,7 @@
                                                                                                       } ],
                                                                                "momentary_positions": "none",
                                                                                            "outputs": [ {
-                                                                                                              "address": 4370,
+                                                                                                              "address": 4368,
                                                                                                           "description": "selector position",
                                                                                                                  "mask": 96,
                                                                                                             "max_value": 2,
@@ -14264,7 +14184,7 @@
                                                                                                 } ],
                                                                          "momentary_positions": "none",
                                                                                      "outputs": [ {
-                                                                                                        "address": 4330,
+                                                                                                        "address": 4328,
                                                                                                     "description": "selector position",
                                                                                                            "mask": 32768,
                                                                                                       "max_value": 1,
@@ -14294,7 +14214,7 @@
                                                                                                 } ],
                                                                          "momentary_positions": "none",
                                                                                      "outputs": [ {
-                                                                                                        "address": 4336,
+                                                                                                        "address": 4334,
                                                                                                     "description": "selector position",
                                                                                                            "mask": 1024,
                                                                                                       "max_value": 1,
@@ -14324,7 +14244,7 @@
                                                                                                 } ],
                                                                          "momentary_positions": "none",
                                                                                      "outputs": [ {
-                                                                                                        "address": 4336,
+                                                                                                        "address": 4334,
                                                                                                     "description": "selector position",
                                                                                                            "mask": 4,
                                                                                                       "max_value": 1,
@@ -14354,7 +14274,7 @@
                                                                                                 } ],
                                                                          "momentary_positions": "none",
                                                                                      "outputs": [ {
-                                                                                                        "address": 4336,
+                                                                                                        "address": 4334,
                                                                                                     "description": "selector position",
                                                                                                            "mask": 8,
                                                                                                       "max_value": 1,
@@ -14384,7 +14304,7 @@
                                                                                                 } ],
                                                                          "momentary_positions": "none",
                                                                                      "outputs": [ {
-                                                                                                        "address": 4336,
+                                                                                                        "address": 4334,
                                                                                                     "description": "selector position",
                                                                                                            "mask": 16,
                                                                                                       "max_value": 1,
@@ -14414,7 +14334,7 @@
                                                                                                 } ],
                                                                          "momentary_positions": "none",
                                                                                      "outputs": [ {
-                                                                                                        "address": 4336,
+                                                                                                        "address": 4334,
                                                                                                     "description": "selector position",
                                                                                                            "mask": 32,
                                                                                                       "max_value": 1,
@@ -14444,7 +14364,7 @@
                                                                                                 } ],
                                                                          "momentary_positions": "none",
                                                                                      "outputs": [ {
-                                                                                                        "address": 4336,
+                                                                                                        "address": 4334,
                                                                                                     "description": "selector position",
                                                                                                            "mask": 64,
                                                                                                       "max_value": 1,
@@ -14474,7 +14394,7 @@
                                                                                                 } ],
                                                                          "momentary_positions": "none",
                                                                                      "outputs": [ {
-                                                                                                        "address": 4336,
+                                                                                                        "address": 4334,
                                                                                                     "description": "selector position",
                                                                                                            "mask": 128,
                                                                                                       "max_value": 1,
@@ -14504,7 +14424,7 @@
                                                                                                 } ],
                                                                          "momentary_positions": "none",
                                                                                      "outputs": [ {
-                                                                                                        "address": 4336,
+                                                                                                        "address": 4334,
                                                                                                     "description": "selector position",
                                                                                                            "mask": 256,
                                                                                                       "max_value": 1,
@@ -14534,7 +14454,7 @@
                                                                                                 } ],
                                                                          "momentary_positions": "none",
                                                                                      "outputs": [ {
-                                                                                                        "address": 4336,
+                                                                                                        "address": 4334,
                                                                                                     "description": "selector position",
                                                                                                            "mask": 512,
                                                                                                       "max_value": 1,
@@ -14564,7 +14484,7 @@
                                                                                                 } ],
                                                                          "momentary_positions": "none",
                                                                                      "outputs": [ {
-                                                                                                        "address": 4338,
+                                                                                                        "address": 4336,
                                                                                                     "description": "selector position",
                                                                                                            "mask": 4,
                                                                                                       "max_value": 1,
@@ -14594,7 +14514,7 @@
                                                                                                 } ],
                                                                          "momentary_positions": "none",
                                                                                      "outputs": [ {
-                                                                                                        "address": 4336,
+                                                                                                        "address": 4334,
                                                                                                     "description": "selector position",
                                                                                                            "mask": 32768,
                                                                                                       "max_value": 1,
@@ -14616,7 +14536,7 @@
                                                                                                 } ],
                                                                          "momentary_positions": "first_and_last",
                                                                                      "outputs": [ {
-                                                                                                        "address": 4338,
+                                                                                                        "address": 4336,
                                                                                                     "description": "selector position",
                                                                                                            "mask": 96,
                                                                                                       "max_value": 2,
@@ -14638,7 +14558,7 @@
                                                                                                 } ],
                                                                          "momentary_positions": "first_and_last",
                                                                                      "outputs": [ {
-                                                                                                        "address": 4338,
+                                                                                                        "address": 4336,
                                                                                                     "description": "selector position",
                                                                                                            "mask": 1536,
                                                                                                       "max_value": 2,
@@ -14668,7 +14588,7 @@
                                                                                                 } ],
                                                                          "momentary_positions": "none",
                                                                                      "outputs": [ {
-                                                                                                        "address": 4338,
+                                                                                                        "address": 4336,
                                                                                                     "description": "selector position",
                                                                                                            "mask": 1,
                                                                                                       "max_value": 1,
@@ -14698,7 +14618,7 @@
                                                                                                 } ],
                                                                          "momentary_positions": "none",
                                                                                      "outputs": [ {
-                                                                                                        "address": 4336,
+                                                                                                        "address": 4334,
                                                                                                     "description": "selector position",
                                                                                                            "mask": 8192,
                                                                                                       "max_value": 1,
@@ -14728,7 +14648,7 @@
                                                                                                 } ],
                                                                          "momentary_positions": "none",
                                                                                      "outputs": [ {
-                                                                                                        "address": 4336,
+                                                                                                        "address": 4334,
                                                                                                     "description": "selector position",
                                                                                                            "mask": 4096,
                                                                                                       "max_value": 1,
@@ -14750,7 +14670,7 @@
                                                                                                 } ],
                                                                          "momentary_positions": "first_and_last",
                                                                                      "outputs": [ {
-                                                                                                        "address": 4338,
+                                                                                                        "address": 4336,
                                                                                                     "description": "selector position",
                                                                                                            "mask": 6144,
                                                                                                       "max_value": 2,
@@ -14780,7 +14700,7 @@
                                                                                                 } ],
                                                                          "momentary_positions": "none",
                                                                                      "outputs": [ {
-                                                                                                        "address": 4336,
+                                                                                                        "address": 4334,
                                                                                                     "description": "selector position",
                                                                                                            "mask": 16384,
                                                                                                       "max_value": 1,
@@ -14810,7 +14730,7 @@
                                                                                                 } ],
                                                                          "momentary_positions": "none",
                                                                                      "outputs": [ {
-                                                                                                        "address": 4340,
+                                                                                                        "address": 4338,
                                                                                                     "description": "selector position",
                                                                                                            "mask": 8,
                                                                                                       "max_value": 1,
@@ -14840,7 +14760,7 @@
                                                                                                 } ],
                                                                          "momentary_positions": "none",
                                                                                      "outputs": [ {
-                                                                                                        "address": 4338,
+                                                                                                        "address": 4336,
                                                                                                     "description": "selector position",
                                                                                                            "mask": 2,
                                                                                                       "max_value": 1,
@@ -14870,7 +14790,7 @@
                                                                                                 } ],
                                                                          "momentary_positions": "none",
                                                                                      "outputs": [ {
-                                                                                                        "address": 4338,
+                                                                                                        "address": 4336,
                                                                                                     "description": "selector position",
                                                                                                            "mask": 8192,
                                                                                                       "max_value": 1,
@@ -14900,7 +14820,7 @@
                                                                                                 } ],
                                                                          "momentary_positions": "none",
                                                                                      "outputs": [ {
-                                                                                                        "address": 4338,
+                                                                                                        "address": 4336,
                                                                                                     "description": "selector position",
                                                                                                            "mask": 16384,
                                                                                                       "max_value": 1,
@@ -14930,7 +14850,7 @@
                                                                                                 } ],
                                                                          "momentary_positions": "none",
                                                                                      "outputs": [ {
-                                                                                                        "address": 4338,
+                                                                                                        "address": 4336,
                                                                                                     "description": "selector position",
                                                                                                            "mask": 32768,
                                                                                                       "max_value": 1,
@@ -14960,7 +14880,7 @@
                                                                                                 } ],
                                                                          "momentary_positions": "none",
                                                                                      "outputs": [ {
-                                                                                                        "address": 4340,
+                                                                                                        "address": 4338,
                                                                                                     "description": "selector position",
                                                                                                            "mask": 1,
                                                                                                       "max_value": 1,
@@ -14990,7 +14910,7 @@
                                                                                                 } ],
                                                                          "momentary_positions": "none",
                                                                                      "outputs": [ {
-                                                                                                        "address": 4340,
+                                                                                                        "address": 4338,
                                                                                                     "description": "selector position",
                                                                                                            "mask": 2,
                                                                                                       "max_value": 1,
@@ -15020,7 +14940,7 @@
                                                                                                 } ],
                                                                          "momentary_positions": "none",
                                                                                      "outputs": [ {
-                                                                                                        "address": 4340,
+                                                                                                        "address": 4338,
                                                                                                     "description": "selector position",
                                                                                                            "mask": 4,
                                                                                                       "max_value": 1,
@@ -15042,7 +14962,7 @@
                                                                                                 } ],
                                                                          "momentary_positions": "first_and_last",
                                                                                      "outputs": [ {
-                                                                                                        "address": 4338,
+                                                                                                        "address": 4336,
                                                                                                     "description": "selector position",
                                                                                                            "mask": 384,
                                                                                                       "max_value": 2,
@@ -15072,7 +14992,7 @@
                                                                                                 } ],
                                                                          "momentary_positions": "none",
                                                                                      "outputs": [ {
-                                                                                                        "address": 4336,
+                                                                                                        "address": 4334,
                                                                                                     "description": "selector position",
                                                                                                            "mask": 2048,
                                                                                                       "max_value": 1,
@@ -15094,7 +15014,7 @@
                                                                                                 } ],
                                                                          "momentary_positions": "first_and_last",
                                                                                      "outputs": [ {
-                                                                                                        "address": 4338,
+                                                                                                        "address": 4336,
                                                                                                     "description": "selector position",
                                                                                                            "mask": 24,
                                                                                                       "max_value": 2,
@@ -15121,15 +15041,15 @@
                                                                                                } ],
                                                                         "momentary_positions": "none",
                                                                                     "outputs": [ {
-                                                                                                       "address": 4466,
+                                                                                                       "address": 4464,
                                                                                                    "description": "selector position",
-                                                                                                          "mask": 24576,
+                                                                                                          "mask": 768,
                                                                                                      "max_value": 2,
-                                                                                                      "shift_by": 13,
+                                                                                                      "shift_by": 8,
                                                                                                         "suffix": "_INT",
                                                                                                           "type": "integer"
                                                                                                }, {
-                                                                                                       "address": 4474,
+                                                                                                       "address": 4472,
                                                                                                    "description": "possible values: \"2\" \"3\" \"A\" ",
                                                                                                     "max_length": 1,
                                                                                                         "suffix": "_STR",
@@ -15152,11 +15072,11 @@
                                                                                                } ],
                                                                         "momentary_positions": "none",
                                                                                     "outputs": [ {
-                                                                                                       "address": 4474,
+                                                                                                       "address": 4464,
                                                                                                    "description": "selector position",
-                                                                                                          "mask": 3840,
+                                                                                                          "mask": 15360,
                                                                                                      "max_value": 9,
-                                                                                                      "shift_by": 8,
+                                                                                                      "shift_by": 10,
                                                                                                         "suffix": "",
                                                                                                           "type": "integer"
                                                                                                } ],
@@ -15177,11 +15097,11 @@
                                                                                                } ],
                                                                         "momentary_positions": "none",
                                                                                     "outputs": [ {
-                                                                                                       "address": 4474,
+                                                                                                       "address": 4472,
                                                                                                    "description": "selector position",
-                                                                                                          "mask": 61440,
+                                                                                                          "mask": 3840,
                                                                                                      "max_value": 9,
-                                                                                                      "shift_by": 12,
+                                                                                                      "shift_by": 8,
                                                                                                         "suffix": "",
                                                                                                           "type": "integer"
                                                                                                } ],
@@ -15208,9 +15128,9 @@
                                                                                     "outputs": [ {
                                                                                                        "address": 4476,
                                                                                                    "description": "selector position",
-                                                                                                          "mask": 16384,
+                                                                                                          "mask": 1024,
                                                                                                      "max_value": 1,
-                                                                                                      "shift_by": 14,
+                                                                                                      "shift_by": 10,
                                                                                                         "suffix": "",
                                                                                                           "type": "integer"
                                                                                                } ],
@@ -15223,7 +15143,7 @@
                                                                           "identifier": "UHF_FREQUENCY",
                                                                               "inputs": [  ],
                                                                              "outputs": [ {
-                                                                                                "address": 4482,
+                                                                                                "address": 4480,
                                                                                             "description": "UHF Frequency Display",
                                                                                              "max_length": 7,
                                                                                                  "suffix": "",
@@ -15247,9 +15167,9 @@
                                                                                     "outputs": [ {
                                                                                                        "address": 4476,
                                                                                                    "description": "selector position",
-                                                                                                          "mask": 768,
+                                                                                                          "mask": 12,
                                                                                                      "max_value": 3,
-                                                                                                      "shift_by": 8,
+                                                                                                      "shift_by": 2,
                                                                                                         "suffix": "",
                                                                                                           "type": "integer"
                                                                                                } ],
@@ -15277,9 +15197,9 @@
                                                                                     "outputs": [ {
                                                                                                        "address": 4476,
                                                                                                    "description": "selector position",
-                                                                                                          "mask": 8192,
+                                                                                                          "mask": 512,
                                                                                                      "max_value": 1,
-                                                                                                      "shift_by": 13,
+                                                                                                      "shift_by": 9,
                                                                                                         "suffix": "",
                                                                                                           "type": "integer"
                                                                                                } ],
@@ -15302,9 +15222,9 @@
                                                                                     "outputs": [ {
                                                                                                        "address": 4476,
                                                                                                    "description": "selector position",
-                                                                                                          "mask": 192,
+                                                                                                          "mask": 3,
                                                                                                      "max_value": 2,
-                                                                                                      "shift_by": 6,
+                                                                                                      "shift_by": 0,
                                                                                                         "suffix": "",
                                                                                                           "type": "integer"
                                                                                                } ],
@@ -15325,11 +15245,11 @@
                                                                                                } ],
                                                                         "momentary_positions": "none",
                                                                                     "outputs": [ {
-                                                                                                       "address": 4476,
+                                                                                                       "address": 4472,
                                                                                                    "description": "selector position",
-                                                                                                          "mask": 15,
+                                                                                                          "mask": 61440,
                                                                                                      "max_value": 9,
-                                                                                                      "shift_by": 0,
+                                                                                                      "shift_by": 12,
                                                                                                         "suffix": "",
                                                                                                           "type": "integer"
                                                                                                } ],
@@ -15350,15 +15270,15 @@
                                                                                                } ],
                                                                         "momentary_positions": "none",
                                                                                     "outputs": [ {
-                                                                                                       "address": 4476,
+                                                                                                       "address": 4464,
                                                                                                    "description": "selector position",
-                                                                                                          "mask": 48,
+                                                                                                          "mask": 49152,
                                                                                                      "max_value": 3,
-                                                                                                      "shift_by": 4,
+                                                                                                      "shift_by": 14,
                                                                                                         "suffix": "_INT",
                                                                                                           "type": "integer"
                                                                                                }, {
-                                                                                                       "address": 4478,
+                                                                                                       "address": 4474,
                                                                                                    "description": "possible values: \"00\" \"25\" \"50\" \"75\" ",
                                                                                                     "max_length": 2,
                                                                                                         "suffix": "_STR",
@@ -15373,7 +15293,7 @@
                                                                           "identifier": "UHF_PRESET",
                                                                               "inputs": [  ],
                                                                              "outputs": [ {
-                                                                                                "address": 4490,
+                                                                                                "address": 4488,
                                                                                             "description": "UHF Preset Display",
                                                                                              "max_length": 2,
                                                                                                  "suffix": "",
@@ -15395,15 +15315,15 @@
                                                                                                } ],
                                                                         "momentary_positions": "none",
                                                                                     "outputs": [ {
-                                                                                                       "address": 4466,
+                                                                                                       "address": 4456,
                                                                                                    "description": "selector position",
-                                                                                                          "mask": 7936,
+                                                                                                          "mask": 63488,
                                                                                                      "max_value": 20,
-                                                                                                      "shift_by": 8,
+                                                                                                      "shift_by": 11,
                                                                                                         "suffix": "_INT",
                                                                                                           "type": "integer"
                                                                                                }, {
-                                                                                                       "address": 4472,
+                                                                                                       "address": 4470,
                                                                                                    "description": "possible values: \" 1\" \" 2\" \" 3\" \" 4\" \" 5\" \" 6\" \" 7\" \" 8\" \" 9\" \"10\" \"11\" \"12\" \"13\" \"14\" \"15\" \"16\" \"17\" \"18\" \"19\" \"20\" ",
                                                                                                     "max_length": 2,
                                                                                                         "suffix": "_STR",
@@ -15430,11 +15350,11 @@
                                                                                                } ],
                                                                         "momentary_positions": "none",
                                                                                     "outputs": [ {
-                                                                                                       "address": 4458,
+                                                                                                       "address": 4476,
                                                                                                    "description": "selector position",
-                                                                                                          "mask": 32768,
+                                                                                                          "mask": 64,
                                                                                                      "max_value": 1,
-                                                                                                      "shift_by": 15,
+                                                                                                      "shift_by": 6,
                                                                                                         "suffix": "",
                                                                                                           "type": "integer"
                                                                                                } ],
@@ -15462,9 +15382,9 @@
                                                                                     "outputs": [ {
                                                                                                        "address": 4476,
                                                                                                    "description": "selector position",
-                                                                                                          "mask": 4096,
+                                                                                                          "mask": 256,
                                                                                                      "max_value": 1,
-                                                                                                      "shift_by": 12,
+                                                                                                      "shift_by": 8,
                                                                                                         "suffix": "",
                                                                                                           "type": "integer"
                                                                                                } ],
@@ -15490,11 +15410,11 @@
                                                                                                } ],
                                                                         "momentary_positions": "none",
                                                                                     "outputs": [ {
-                                                                                                       "address": 4466,
+                                                                                                       "address": 4476,
                                                                                                    "description": "selector position",
-                                                                                                          "mask": 32768,
+                                                                                                          "mask": 128,
                                                                                                      "max_value": 1,
-                                                                                                      "shift_by": 15,
+                                                                                                      "shift_by": 7,
                                                                                                         "suffix": "",
                                                                                                           "type": "integer"
                                                                                                } ],
@@ -15517,9 +15437,9 @@
                                                                                     "outputs": [ {
                                                                                                        "address": 4476,
                                                                                                    "description": "selector position",
-                                                                                                          "mask": 3072,
+                                                                                                          "mask": 48,
                                                                                                      "max_value": 2,
-                                                                                                      "shift_by": 10,
+                                                                                                      "shift_by": 4,
                                                                                                         "suffix": "",
                                                                                                           "type": "integer"
                                                                                                } ],
@@ -15541,7 +15461,7 @@
                                                                                             "suggested_step": 3200
                                                                                         } ],
                                                                              "outputs": [ {
-                                                                                                "address": 4480,
+                                                                                                "address": 4478,
                                                                                             "description": "position of the potentiometer",
                                                                                                    "mask": 65535,
                                                                                               "max_value": 65535,
@@ -15565,13 +15485,13 @@
                                                                                   "outputs": [ {
                                                                                                      "address": 4494,
                                                                                                  "description": "selector position",
-                                                                                                        "mask": 240,
+                                                                                                        "mask": 15,
                                                                                                    "max_value": 12,
-                                                                                                    "shift_by": 4,
+                                                                                                    "shift_by": 0,
                                                                                                       "suffix": "_INT",
                                                                                                         "type": "integer"
                                                                                              }, {
-                                                                                                     "address": 4498,
+                                                                                                     "address": 4496,
                                                                                                  "description": "possible values: \" 3\" \" 4\" \" 5\" \" 6\" \" 7\" \" 8\" \" 9\" \"10\" \"11\" \"12\" \"13\" \"14\" \"15\" ",
                                                                                                   "max_length": 2,
                                                                                                       "suffix": "_STR",
@@ -15586,11 +15506,11 @@
                                                                         "identifier": "VHFAM_FREQ1_ROT",
                                                                             "inputs": [  ],
                                                                            "outputs": [ {
-                                                                                              "address": 4542,
+                                                                                              "address": 4540,
                                                                                           "description": "gauge position",
-                                                                                                 "mask": 32640,
+                                                                                                 "mask": 2040,
                                                                                             "max_value": 255,
-                                                                                             "shift_by": 7,
+                                                                                             "shift_by": 3,
                                                                                                "suffix": "",
                                                                                                  "type": "integer"
                                                                                       } ]
@@ -15608,9 +15528,9 @@
                                                                                   "outputs": [ {
                                                                                                      "address": 4494,
                                                                                                  "description": "selector position",
-                                                                                                        "mask": 3840,
+                                                                                                        "mask": 240,
                                                                                                    "max_value": 9,
-                                                                                                    "shift_by": 8,
+                                                                                                    "shift_by": 4,
                                                                                                       "suffix": "",
                                                                                                         "type": "integer"
                                                                                              } ],
@@ -15623,7 +15543,7 @@
                                                                         "identifier": "VHFAM_FREQ2_ROT",
                                                                             "inputs": [  ],
                                                                            "outputs": [ {
-                                                                                              "address": 4794,
+                                                                                              "address": 4792,
                                                                                           "description": "gauge position",
                                                                                                  "mask": 255,
                                                                                             "max_value": 255,
@@ -15645,9 +15565,9 @@
                                                                                   "outputs": [ {
                                                                                                      "address": 4494,
                                                                                                  "description": "selector position",
-                                                                                                        "mask": 61440,
+                                                                                                        "mask": 3840,
                                                                                                    "max_value": 9,
-                                                                                                    "shift_by": 12,
+                                                                                                    "shift_by": 8,
                                                                                                       "suffix": "",
                                                                                                         "type": "integer"
                                                                                              } ],
@@ -15660,7 +15580,7 @@
                                                                         "identifier": "VHFAM_FREQ3_ROT",
                                                                             "inputs": [  ],
                                                                            "outputs": [ {
-                                                                                              "address": 4794,
+                                                                                              "address": 4792,
                                                                                           "description": "gauge position",
                                                                                                  "mask": 65280,
                                                                                             "max_value": 255,
@@ -15680,15 +15600,15 @@
                                                                                              } ],
                                                                       "momentary_positions": "none",
                                                                                   "outputs": [ {
-                                                                                                     "address": 4500,
+                                                                                                     "address": 4494,
                                                                                                  "description": "selector position",
-                                                                                                        "mask": 7,
+                                                                                                        "mask": 28672,
                                                                                                    "max_value": 3,
-                                                                                                    "shift_by": 0,
+                                                                                                    "shift_by": 12,
                                                                                                       "suffix": "_INT",
                                                                                                         "type": "integer"
                                                                                              }, {
-                                                                                                     "address": 4502,
+                                                                                                     "address": 4498,
                                                                                                  "description": "possible values: \"00\" \"25\" \"50\" \"75\" ",
                                                                                                   "max_length": 2,
                                                                                                       "suffix": "_STR",
@@ -15703,7 +15623,7 @@
                                                                         "identifier": "VHFAM_FREQ4_ROT",
                                                                             "inputs": [  ],
                                                                            "outputs": [ {
-                                                                                              "address": 4796,
+                                                                                              "address": 4794,
                                                                                           "description": "gauge position",
                                                                                                  "mask": 255,
                                                                                             "max_value": 255,
@@ -15727,11 +15647,11 @@
                                                                                              } ],
                                                                       "momentary_positions": "none",
                                                                                   "outputs": [ {
-                                                                                                     "address": 4494,
+                                                                                                     "address": 4486,
                                                                                                  "description": "selector position",
-                                                                                                        "mask": 3,
+                                                                                                        "mask": 3072,
                                                                                                    "max_value": 3,
-                                                                                                    "shift_by": 0,
+                                                                                                    "shift_by": 10,
                                                                                                       "suffix": "",
                                                                                                         "type": "integer"
                                                                                              } ],
@@ -15757,11 +15677,11 @@
                                                                                              } ],
                                                                       "momentary_positions": "none",
                                                                                   "outputs": [ {
-                                                                                                     "address": 4476,
+                                                                                                     "address": 4486,
                                                                                                  "description": "selector position",
-                                                                                                        "mask": 32768,
+                                                                                                        "mask": 4096,
                                                                                                    "max_value": 1,
-                                                                                                    "shift_by": 15,
+                                                                                                    "shift_by": 12,
                                                                                                       "suffix": "",
                                                                                                         "type": "integer"
                                                                                              } ],
@@ -15782,11 +15702,11 @@
                                                                                              } ],
                                                                       "momentary_positions": "none",
                                                                                   "outputs": [ {
-                                                                                                     "address": 4488,
+                                                                                                     "address": 4486,
                                                                                                  "description": "selector position",
-                                                                                                        "mask": 24576,
+                                                                                                        "mask": 768,
                                                                                                    "max_value": 2,
-                                                                                                    "shift_by": 13,
+                                                                                                    "shift_by": 8,
                                                                                                       "suffix": "",
                                                                                                         "type": "integer"
                                                                                              } ],
@@ -15807,15 +15727,15 @@
                                                                                              } ],
                                                                       "momentary_positions": "none",
                                                                                   "outputs": [ {
-                                                                                                     "address": 4488,
+                                                                                                     "address": 4476,
                                                                                                  "description": "selector position",
-                                                                                                        "mask": 7936,
+                                                                                                        "mask": 63488,
                                                                                                    "max_value": 19,
-                                                                                                    "shift_by": 8,
+                                                                                                    "shift_by": 11,
                                                                                                       "suffix": "_INT",
                                                                                                         "type": "integer"
                                                                                              }, {
-                                                                                                     "address": 4492,
+                                                                                                     "address": 4490,
                                                                                                  "description": "possible values: \" 1\" \" 2\" \" 3\" \" 4\" \" 5\" \" 6\" \" 7\" \" 8\" \" 9\" \"10\" \"11\" \"12\" \"13\" \"14\" \"15\" \"16\" \"17\" \"18\" \"19\" \"20\" ",
                                                                                                   "max_length": 2,
                                                                                                       "suffix": "_STR",
@@ -15838,11 +15758,11 @@
                                                                                              } ],
                                                                       "momentary_positions": "none",
                                                                                   "outputs": [ {
-                                                                                                     "address": 4494,
+                                                                                                     "address": 4486,
                                                                                                  "description": "selector position",
-                                                                                                        "mask": 12,
+                                                                                                        "mask": 24576,
                                                                                                    "max_value": 2,
-                                                                                                    "shift_by": 2,
+                                                                                                    "shift_by": 13,
                                                                                                       "suffix": "",
                                                                                                         "type": "integer"
                                                                                              } ],
@@ -15864,7 +15784,7 @@
                                                                                           "suggested_step": 3200
                                                                                       } ],
                                                                            "outputs": [ {
-                                                                                              "address": 4496,
+                                                                                              "address": 4492,
                                                                                           "description": "position of the potentiometer",
                                                                                                  "mask": 65535,
                                                                                             "max_value": 65535,
@@ -15886,15 +15806,15 @@
                                                                                              } ],
                                                                       "momentary_positions": "none",
                                                                                   "outputs": [ {
-                                                                                                     "address": 4508,
+                                                                                                     "address": 4500,
                                                                                                  "description": "selector position",
-                                                                                                        "mask": 15,
+                                                                                                        "mask": 30720,
                                                                                                    "max_value": 12,
-                                                                                                    "shift_by": 0,
+                                                                                                    "shift_by": 11,
                                                                                                       "suffix": "_INT",
                                                                                                         "type": "integer"
                                                                                              }, {
-                                                                                                     "address": 4510,
+                                                                                                     "address": 4506,
                                                                                                  "description": "possible values: \" 3\" \" 4\" \" 5\" \" 6\" \" 7\" \" 8\" \" 9\" \"10\" \"11\" \"12\" \"13\" \"14\" \"15\" ",
                                                                                                   "max_length": 2,
                                                                                                       "suffix": "_STR",
@@ -15909,7 +15829,7 @@
                                                                         "identifier": "VHFFM_FREQ1_ROT",
                                                                             "inputs": [  ],
                                                                            "outputs": [ {
-                                                                                              "address": 4796,
+                                                                                              "address": 4794,
                                                                                           "description": "gauge position",
                                                                                                  "mask": 65280,
                                                                                             "max_value": 255,
@@ -15931,9 +15851,9 @@
                                                                                   "outputs": [ {
                                                                                                      "address": 4508,
                                                                                                  "description": "selector position",
-                                                                                                        "mask": 240,
+                                                                                                        "mask": 15,
                                                                                                    "max_value": 9,
-                                                                                                    "shift_by": 4,
+                                                                                                    "shift_by": 0,
                                                                                                       "suffix": "",
                                                                                                         "type": "integer"
                                                                                              } ],
@@ -15946,7 +15866,7 @@
                                                                         "identifier": "VHFFM_FREQ2_ROT",
                                                                             "inputs": [  ],
                                                                            "outputs": [ {
-                                                                                              "address": 4798,
+                                                                                              "address": 4796,
                                                                                           "description": "gauge position",
                                                                                                  "mask": 255,
                                                                                             "max_value": 255,
@@ -15968,9 +15888,9 @@
                                                                                   "outputs": [ {
                                                                                                      "address": 4508,
                                                                                                  "description": "selector position",
-                                                                                                        "mask": 3840,
+                                                                                                        "mask": 240,
                                                                                                    "max_value": 9,
-                                                                                                    "shift_by": 8,
+                                                                                                    "shift_by": 4,
                                                                                                       "suffix": "",
                                                                                                         "type": "integer"
                                                                                              } ],
@@ -15983,7 +15903,7 @@
                                                                         "identifier": "VHFFM_FREQ3_ROT",
                                                                             "inputs": [  ],
                                                                            "outputs": [ {
-                                                                                              "address": 4798,
+                                                                                              "address": 4796,
                                                                                           "description": "gauge position",
                                                                                                  "mask": 65280,
                                                                                             "max_value": 255,
@@ -16005,13 +15925,13 @@
                                                                                   "outputs": [ {
                                                                                                      "address": 4508,
                                                                                                  "description": "selector position",
-                                                                                                        "mask": 28672,
+                                                                                                        "mask": 1792,
                                                                                                    "max_value": 3,
-                                                                                                    "shift_by": 12,
+                                                                                                    "shift_by": 8,
                                                                                                       "suffix": "_INT",
                                                                                                         "type": "integer"
                                                                                              }, {
-                                                                                                     "address": 4512,
+                                                                                                     "address": 4510,
                                                                                                  "description": "possible values: \"00\" \"25\" \"50\" \"75\" ",
                                                                                                   "max_length": 2,
                                                                                                       "suffix": "_STR",
@@ -16026,7 +15946,7 @@
                                                                         "identifier": "VHFFM_FREQ4_ROT",
                                                                             "inputs": [  ],
                                                                            "outputs": [ {
-                                                                                              "address": 4800,
+                                                                                              "address": 4798,
                                                                                           "description": "gauge position",
                                                                                                  "mask": 255,
                                                                                             "max_value": 255,
@@ -16052,9 +15972,9 @@
                                                                                   "outputs": [ {
                                                                                                      "address": 4500,
                                                                                                  "description": "selector position",
-                                                                                                        "mask": 3072,
+                                                                                                        "mask": 384,
                                                                                                    "max_value": 3,
-                                                                                                    "shift_by": 10,
+                                                                                                    "shift_by": 7,
                                                                                                       "suffix": "",
                                                                                                         "type": "integer"
                                                                                              } ],
@@ -16080,7 +16000,7 @@
                                                                                              } ],
                                                                       "momentary_positions": "none",
                                                                                   "outputs": [ {
-                                                                                                     "address": 4488,
+                                                                                                     "address": 4486,
                                                                                                  "description": "selector position",
                                                                                                         "mask": 32768,
                                                                                                    "max_value": 1,
@@ -16107,9 +16027,9 @@
                                                                                   "outputs": [ {
                                                                                                      "address": 4500,
                                                                                                  "description": "selector position",
-                                                                                                        "mask": 768,
+                                                                                                        "mask": 96,
                                                                                                    "max_value": 2,
-                                                                                                    "shift_by": 8,
+                                                                                                    "shift_by": 5,
                                                                                                       "suffix": "",
                                                                                                         "type": "integer"
                                                                                              } ],
@@ -16132,13 +16052,13 @@
                                                                                   "outputs": [ {
                                                                                                      "address": 4500,
                                                                                                  "description": "selector position",
-                                                                                                        "mask": 248,
+                                                                                                        "mask": 31,
                                                                                                    "max_value": 19,
-                                                                                                    "shift_by": 3,
+                                                                                                    "shift_by": 0,
                                                                                                       "suffix": "_INT",
                                                                                                         "type": "integer"
                                                                                              }, {
-                                                                                                     "address": 4504,
+                                                                                                     "address": 4502,
                                                                                                  "description": "possible values: \" 1\" \" 2\" \" 3\" \" 4\" \" 5\" \" 6\" \" 7\" \" 8\" \" 9\" \"10\" \"11\" \"12\" \"13\" \"14\" \"15\" \"16\" \"17\" \"18\" \"19\" \"20\" ",
                                                                                                   "max_length": 2,
                                                                                                       "suffix": "_STR",
@@ -16163,9 +16083,9 @@
                                                                                   "outputs": [ {
                                                                                                      "address": 4500,
                                                                                                  "description": "selector position",
-                                                                                                        "mask": 12288,
+                                                                                                        "mask": 1536,
                                                                                                    "max_value": 2,
-                                                                                                    "shift_by": 12,
+                                                                                                    "shift_by": 9,
                                                                                                       "suffix": "",
                                                                                                         "type": "integer"
                                                                                              } ],
@@ -16187,7 +16107,7 @@
                                                                                           "suggested_step": 3200
                                                                                       } ],
                                                                            "outputs": [ {
-                                                                                              "address": 4506,
+                                                                                              "address": 4504,
                                                                                           "description": "position of the potentiometer",
                                                                                                  "mask": 65535,
                                                                                             "max_value": 65535,

--- a/src/control-reference-json/AV8BNA.json
+++ b/src/control-reference-json/AV8BNA.json
@@ -2154,22 +2154,16 @@
                               "Fuel Panel": {
                                                   "BINGO_SET": {
                                                                        "category": "Fuel Panel",
-                                                                   "control_type": "limited_dial",
+                                                                   "control_type": "fixed_step_dial",
                                                                     "description": "Bingo Fuel Set Knob",
                                                                      "identifier": "BINGO_SET",
                                                                          "inputs": [ {
-                                                                                       "description": "set the position of the dial",
-                                                                                         "interface": "set_state",
-                                                                                         "max_value": 65535
-                                                                                   }, {
-                                                                                          "description": "turn the dial left or right",
-                                                                                            "interface": "variable_step",
-                                                                                            "max_value": 65535,
-                                                                                       "suggested_step": 3200
+                                                                                       "description": "rotate the knob left or right",
+                                                                                         "interface": "fixed_step"
                                                                                    } ],
                                                                         "outputs": [ {
                                                                                            "address": 30760,
-                                                                                       "description": "position of the potentiometer",
+                                                                                       "description": "rotation of the knob",
                                                                                               "mask": 65535,
                                                                                          "max_value": 65535,
                                                                                           "shift_by": 0,

--- a/src/control-reference-json/UH-1H.json
+++ b/src/control-reference-json/UH-1H.json
@@ -15,7 +15,7 @@
                                                                                               } ],
                                                                        "momentary_positions": "none",
                                                                                    "outputs": [ {
-                                                                                                      "address": 5378,
+                                                                                                      "address": 5372,
                                                                                                   "description": "selector position",
                                                                                                          "mask": 3,
                                                                                                     "max_value": 2,
@@ -44,7 +44,7 @@
                                                                                               } ],
                                                                        "momentary_positions": "none",
                                                                                    "outputs": [ {
-                                                                                                      "address": 5362,
+                                                                                                      "address": 5356,
                                                                                                   "description": "selector position",
                                                                                                          "mask": 4096,
                                                                                                     "max_value": 1,
@@ -86,7 +86,7 @@
                                                                                            "suggested_step": 3200
                                                                                        } ],
                                                                             "outputs": [ {
-                                                                                               "address": 5376,
+                                                                                               "address": 5370,
                                                                                            "description": "position of the potentiometer",
                                                                                                   "mask": 65535,
                                                                                              "max_value": 65535,
@@ -110,7 +110,7 @@
                                                                                               } ],
                                                                        "momentary_positions": "none",
                                                                                    "outputs": [ {
-                                                                                                      "address": 5362,
+                                                                                                      "address": 5356,
                                                                                                   "description": "selector position",
                                                                                                          "mask": 3584,
                                                                                                     "max_value": 4,
@@ -135,7 +135,7 @@
                                                                                               } ],
                                                                        "momentary_positions": "none",
                                                                                    "outputs": [ {
-                                                                                                      "address": 5362,
+                                                                                                      "address": 5356,
                                                                                                   "description": "selector position",
                                                                                                          "mask": 24576,
                                                                                                     "max_value": 2,
@@ -174,7 +174,7 @@
                                                                                            "suggested_step": 3200
                                                                                        } ],
                                                                             "outputs": [ {
-                                                                                               "address": 5380,
+                                                                                               "address": 5374,
                                                                                            "description": "the rotation of the knob in the cockpit (not the value that is controlled by this knob!)",
                                                                                                   "mask": 65535,
                                                                                              "max_value": 65535,
@@ -412,7 +412,7 @@
                                                                                                 } ],
                                                                          "momentary_positions": "none",
                                                                                      "outputs": [ {
-                                                                                                        "address": 5394,
+                                                                                                        "address": 5388,
                                                                                                     "description": "selector position",
                                                                                                            "mask": 192,
                                                                                                       "max_value": 2,
@@ -442,7 +442,7 @@
                                                                                                 } ],
                                                                          "momentary_positions": "none",
                                                                                      "outputs": [ {
-                                                                                                        "address": 5402,
+                                                                                                        "address": 5396,
                                                                                                     "description": "selector position",
                                                                                                            "mask": 1,
                                                                                                       "max_value": 1,
@@ -467,7 +467,7 @@
                                                                                                 } ],
                                                                          "momentary_positions": "none",
                                                                                      "outputs": [ {
-                                                                                                        "address": 5394,
+                                                                                                        "address": 5388,
                                                                                                     "description": "selector position",
                                                                                                            "mask": 49152,
                                                                                                       "max_value": 2,
@@ -492,7 +492,7 @@
                                                                                                 } ],
                                                                          "momentary_positions": "none",
                                                                                      "outputs": [ {
-                                                                                                        "address": 5394,
+                                                                                                        "address": 5388,
                                                                                                     "description": "selector position",
                                                                                                            "mask": 48,
                                                                                                       "max_value": 2,
@@ -517,7 +517,7 @@
                                                                                                 } ],
                                                                          "momentary_positions": "none",
                                                                                      "outputs": [ {
-                                                                                                        "address": 5394,
+                                                                                                        "address": 5388,
                                                                                                     "description": "selector position",
                                                                                                            "mask": 7168,
                                                                                                       "max_value": 7,
@@ -547,7 +547,7 @@
                                                                                                 } ],
                                                                          "momentary_positions": "none",
                                                                                      "outputs": [ {
-                                                                                                        "address": 5394,
+                                                                                                        "address": 5388,
                                                                                                     "description": "selector position",
                                                                                                            "mask": 8192,
                                                                                                       "max_value": 1,
@@ -572,7 +572,7 @@
                                                                                                 } ],
                                                                          "momentary_positions": "none",
                                                                                      "outputs": [ {
-                                                                                                        "address": 5394,
+                                                                                                        "address": 5388,
                                                                                                     "description": "selector position",
                                                                                                            "mask": 768,
                                                                                                       "max_value": 2,
@@ -605,11 +605,11 @@
                                                                            "identifier": "X130_ARMED",
                                                                                "inputs": [  ],
                                                                               "outputs": [ {
-                                                                                                 "address": 5412,
+                                                                                                 "address": 5404,
                                                                                              "description": "0 if light is off, 1 if light is on",
-                                                                                                    "mask": 4,
+                                                                                                    "mask": 64,
                                                                                                "max_value": 1,
-                                                                                                "shift_by": 2,
+                                                                                                "shift_by": 6,
                                                                                                   "suffix": "",
                                                                                                     "type": "integer"
                                                                                          } ]
@@ -628,7 +628,7 @@
                                                                                                     } ],
                                                                              "momentary_positions": "first_and_last",
                                                                                          "outputs": [ {
-                                                                                                            "address": 5310,
+                                                                                                            "address": 5304,
                                                                                                         "description": "selector position",
                                                                                                                "mask": 768,
                                                                                                           "max_value": 2,
@@ -650,7 +650,7 @@
                                                                                                     } ],
                                                                              "momentary_positions": "first_and_last",
                                                                                          "outputs": [ {
-                                                                                                            "address": 5310,
+                                                                                                            "address": 5304,
                                                                                                         "description": "selector position",
                                                                                                                "mask": 192,
                                                                                                           "max_value": 2,
@@ -994,7 +994,7 @@
                                                                                                 } ],
                                                                          "momentary_positions": "first_and_last",
                                                                                      "outputs": [ {
-                                                                                                        "address": 5316,
+                                                                                                        "address": 5310,
                                                                                                     "description": "selector position",
                                                                                                            "mask": 384,
                                                                                                       "max_value": 2,
@@ -1023,7 +1023,7 @@
                                                                                                 } ],
                                                                          "momentary_positions": "none",
                                                                                      "outputs": [ {
-                                                                                                        "address": 5316,
+                                                                                                        "address": 5310,
                                                                                                     "description": "selector position",
                                                                                                            "mask": 2048,
                                                                                                       "max_value": 1,
@@ -1052,7 +1052,7 @@
                                                                                                 } ],
                                                                          "momentary_positions": "none",
                                                                                      "outputs": [ {
-                                                                                                        "address": 5316,
+                                                                                                        "address": 5310,
                                                                                                     "description": "selector position",
                                                                                                            "mask": 1024,
                                                                                                       "max_value": 1,
@@ -1083,7 +1083,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5308,
+                                                                                                             "address": 5302,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 2048,
                                                                                                            "max_value": 1,
@@ -1112,7 +1112,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5304,
+                                                                                                             "address": 5298,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 1024,
                                                                                                            "max_value": 1,
@@ -1141,7 +1141,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5302,
+                                                                                                             "address": 5296,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 32,
                                                                                                            "max_value": 1,
@@ -1170,7 +1170,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5304,
+                                                                                                             "address": 5298,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 1,
                                                                                                            "max_value": 1,
@@ -1199,7 +1199,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5304,
+                                                                                                             "address": 5298,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 8192,
                                                                                                            "max_value": 1,
@@ -1228,7 +1228,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5300,
+                                                                                                             "address": 5294,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 32768,
                                                                                                            "max_value": 1,
@@ -1257,7 +1257,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5302,
+                                                                                                             "address": 5296,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 256,
                                                                                                            "max_value": 1,
@@ -1286,7 +1286,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5304,
+                                                                                                             "address": 5298,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 32,
                                                                                                            "max_value": 1,
@@ -1315,7 +1315,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5304,
+                                                                                                             "address": 5298,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 16,
                                                                                                            "max_value": 1,
@@ -1344,7 +1344,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5304,
+                                                                                                             "address": 5298,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 64,
                                                                                                            "max_value": 1,
@@ -1373,7 +1373,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5308,
+                                                                                                             "address": 5302,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 64,
                                                                                                            "max_value": 1,
@@ -1402,7 +1402,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5308,
+                                                                                                             "address": 5302,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 128,
                                                                                                            "max_value": 1,
@@ -1431,7 +1431,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5310,
+                                                                                                             "address": 5304,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 2,
                                                                                                            "max_value": 1,
@@ -1460,7 +1460,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5304,
+                                                                                                             "address": 5298,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 8,
                                                                                                            "max_value": 1,
@@ -1489,7 +1489,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5310,
+                                                                                                             "address": 5304,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 1,
                                                                                                            "max_value": 1,
@@ -1518,7 +1518,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5308,
+                                                                                                             "address": 5302,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 4096,
                                                                                                            "max_value": 1,
@@ -1547,7 +1547,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5304,
+                                                                                                             "address": 5298,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 16384,
                                                                                                            "max_value": 1,
@@ -1576,7 +1576,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5302,
+                                                                                                             "address": 5296,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 16,
                                                                                                            "max_value": 1,
@@ -1605,7 +1605,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5302,
+                                                                                                             "address": 5296,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 4,
                                                                                                            "max_value": 1,
@@ -1634,7 +1634,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5308,
+                                                                                                             "address": 5302,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 8192,
                                                                                                            "max_value": 1,
@@ -1663,7 +1663,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5308,
+                                                                                                             "address": 5302,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 1024,
                                                                                                            "max_value": 1,
@@ -1692,7 +1692,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5306,
+                                                                                                             "address": 5300,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 16384,
                                                                                                            "max_value": 1,
@@ -1721,7 +1721,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5306,
+                                                                                                             "address": 5300,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 32768,
                                                                                                            "max_value": 1,
@@ -1750,7 +1750,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5304,
+                                                                                                             "address": 5298,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 2,
                                                                                                            "max_value": 1,
@@ -1779,7 +1779,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5306,
+                                                                                                             "address": 5300,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 512,
                                                                                                            "max_value": 1,
@@ -1808,7 +1808,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5306,
+                                                                                                             "address": 5300,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 2048,
                                                                                                            "max_value": 1,
@@ -1837,7 +1837,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5308,
+                                                                                                             "address": 5302,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 512,
                                                                                                            "max_value": 1,
@@ -1866,7 +1866,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5308,
+                                                                                                             "address": 5302,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 1,
                                                                                                            "max_value": 1,
@@ -1895,7 +1895,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5308,
+                                                                                                             "address": 5302,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 2,
                                                                                                            "max_value": 1,
@@ -1924,7 +1924,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5302,
+                                                                                                             "address": 5296,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 1,
                                                                                                            "max_value": 1,
@@ -1953,7 +1953,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5302,
+                                                                                                             "address": 5296,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 2,
                                                                                                            "max_value": 1,
@@ -1982,7 +1982,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5306,
+                                                                                                             "address": 5300,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 16,
                                                                                                            "max_value": 1,
@@ -2011,7 +2011,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5306,
+                                                                                                             "address": 5300,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 4,
                                                                                                            "max_value": 1,
@@ -2040,7 +2040,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5306,
+                                                                                                             "address": 5300,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 4096,
                                                                                                            "max_value": 1,
@@ -2069,7 +2069,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5300,
+                                                                                                             "address": 5294,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 128,
                                                                                                            "max_value": 1,
@@ -2098,7 +2098,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5300,
+                                                                                                             "address": 5294,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 256,
                                                                                                            "max_value": 1,
@@ -2127,7 +2127,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5308,
+                                                                                                             "address": 5302,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 8,
                                                                                                            "max_value": 1,
@@ -2156,7 +2156,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5304,
+                                                                                                             "address": 5298,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 128,
                                                                                                            "max_value": 1,
@@ -2185,7 +2185,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5304,
+                                                                                                             "address": 5298,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 256,
                                                                                                            "max_value": 1,
@@ -2214,7 +2214,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5300,
+                                                                                                             "address": 5294,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 8192,
                                                                                                            "max_value": 1,
@@ -2243,7 +2243,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5300,
+                                                                                                             "address": 5294,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 16384,
                                                                                                            "max_value": 1,
@@ -2272,7 +2272,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5306,
+                                                                                                             "address": 5300,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 128,
                                                                                                            "max_value": 1,
@@ -2301,7 +2301,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5306,
+                                                                                                             "address": 5300,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 32,
                                                                                                            "max_value": 1,
@@ -2330,7 +2330,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5302,
+                                                                                                             "address": 5296,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 2048,
                                                                                                            "max_value": 1,
@@ -2359,7 +2359,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5302,
+                                                                                                             "address": 5296,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 16384,
                                                                                                            "max_value": 1,
@@ -2388,7 +2388,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5300,
+                                                                                                             "address": 5294,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 4096,
                                                                                                            "max_value": 1,
@@ -2417,7 +2417,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5304,
+                                                                                                             "address": 5298,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 32768,
                                                                                                            "max_value": 1,
@@ -2446,7 +2446,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5306,
+                                                                                                             "address": 5300,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 256,
                                                                                                            "max_value": 1,
@@ -2475,7 +2475,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5300,
+                                                                                                             "address": 5294,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 1024,
                                                                                                            "max_value": 1,
@@ -2504,7 +2504,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5304,
+                                                                                                             "address": 5298,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 4,
                                                                                                            "max_value": 1,
@@ -2533,7 +2533,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5304,
+                                                                                                             "address": 5298,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 512,
                                                                                                            "max_value": 1,
@@ -2562,7 +2562,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5302,
+                                                                                                             "address": 5296,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 64,
                                                                                                            "max_value": 1,
@@ -2591,7 +2591,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5308,
+                                                                                                             "address": 5302,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 256,
                                                                                                            "max_value": 1,
@@ -2620,7 +2620,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5308,
+                                                                                                             "address": 5302,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 32,
                                                                                                            "max_value": 1,
@@ -2649,7 +2649,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5300,
+                                                                                                             "address": 5294,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 512,
                                                                                                            "max_value": 1,
@@ -2678,7 +2678,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5302,
+                                                                                                             "address": 5296,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 128,
                                                                                                            "max_value": 1,
@@ -2707,7 +2707,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5304,
+                                                                                                             "address": 5298,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 2048,
                                                                                                            "max_value": 1,
@@ -2736,7 +2736,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5306,
+                                                                                                             "address": 5300,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 8192,
                                                                                                            "max_value": 1,
@@ -2765,7 +2765,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5304,
+                                                                                                             "address": 5298,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 4096,
                                                                                                            "max_value": 1,
@@ -2794,7 +2794,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5302,
+                                                                                                             "address": 5296,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 32768,
                                                                                                            "max_value": 1,
@@ -2823,7 +2823,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5302,
+                                                                                                             "address": 5296,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 8192,
                                                                                                            "max_value": 1,
@@ -2852,7 +2852,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5306,
+                                                                                                             "address": 5300,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 64,
                                                                                                            "max_value": 1,
@@ -2881,7 +2881,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5302,
+                                                                                                             "address": 5296,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 4096,
                                                                                                            "max_value": 1,
@@ -2910,7 +2910,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5306,
+                                                                                                             "address": 5300,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 1024,
                                                                                                            "max_value": 1,
@@ -2939,7 +2939,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5306,
+                                                                                                             "address": 5300,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 2,
                                                                                                            "max_value": 1,
@@ -2968,7 +2968,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5308,
+                                                                                                             "address": 5302,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 16384,
                                                                                                            "max_value": 1,
@@ -2997,7 +2997,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5306,
+                                                                                                             "address": 5300,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 8,
                                                                                                            "max_value": 1,
@@ -3026,7 +3026,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5306,
+                                                                                                             "address": 5300,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 1,
                                                                                                            "max_value": 1,
@@ -3055,7 +3055,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5302,
+                                                                                                             "address": 5296,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 8,
                                                                                                            "max_value": 1,
@@ -3084,7 +3084,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5300,
+                                                                                                             "address": 5294,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 2048,
                                                                                                            "max_value": 1,
@@ -3113,7 +3113,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5308,
+                                                                                                             "address": 5302,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 4,
                                                                                                            "max_value": 1,
@@ -3142,7 +3142,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5302,
+                                                                                                             "address": 5296,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 512,
                                                                                                            "max_value": 1,
@@ -3171,7 +3171,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5302,
+                                                                                                             "address": 5296,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 1024,
                                                                                                            "max_value": 1,
@@ -3200,7 +3200,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5308,
+                                                                                                             "address": 5302,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 32768,
                                                                                                            "max_value": 1,
@@ -3225,7 +3225,7 @@
                                                                                                  "suggested_step": 3200
                                                                                              } ],
                                                                                   "outputs": [ {
-                                                                                                     "address": 5322,
+                                                                                                     "address": 5316,
                                                                                                  "description": "the rotation of the knob in the cockpit (not the value that is controlled by this knob!)",
                                                                                                         "mask": 65535,
                                                                                                    "max_value": 65535,
@@ -3246,7 +3246,7 @@
                                                                                                     } ],
                                                                              "momentary_positions": "none",
                                                                                          "outputs": [ {
-                                                                                                            "address": 5316,
+                                                                                                            "address": 5310,
                                                                                                         "description": "selector position",
                                                                                                                "mask": 8,
                                                                                                           "max_value": 1,
@@ -3270,7 +3270,7 @@
                                                                                                   } ],
                                                                            "momentary_positions": "first_and_last",
                                                                                        "outputs": [ {
-                                                                                                          "address": 5316,
+                                                                                                          "address": 5310,
                                                                                                       "description": "selector position",
                                                                                                              "mask": 12288,
                                                                                                         "max_value": 2,
@@ -3299,7 +3299,7 @@
                                                                                                   } ],
                                                                            "momentary_positions": "none",
                                                                                        "outputs": [ {
-                                                                                                          "address": 5378,
+                                                                                                          "address": 5372,
                                                                                                       "description": "selector position",
                                                                                                              "mask": 256,
                                                                                                         "max_value": 1,
@@ -3324,7 +3324,7 @@
                                                                                                   } ],
                                                                            "momentary_positions": "none",
                                                                                        "outputs": [ {
-                                                                                                          "address": 5378,
+                                                                                                          "address": 5372,
                                                                                                       "description": "selector position",
                                                                                                              "mask": 6144,
                                                                                                         "max_value": 2,
@@ -3349,7 +3349,7 @@
                                                                                                   } ],
                                                                            "momentary_positions": "none",
                                                                                        "outputs": [ {
-                                                                                                          "address": 5378,
+                                                                                                          "address": 5372,
                                                                                                       "description": "selector position",
                                                                                                              "mask": 1536,
                                                                                                         "max_value": 2,
@@ -3375,7 +3375,7 @@
                                                                                                "suggested_step": 3200
                                                                                            } ],
                                                                                 "outputs": [ {
-                                                                                                   "address": 5324,
+                                                                                                   "address": 5318,
                                                                                                "description": "position of the potentiometer",
                                                                                                       "mask": 65535,
                                                                                                  "max_value": 65535,
@@ -3403,7 +3403,7 @@
                                                                                                   } ],
                                                                            "momentary_positions": "none",
                                                                                        "outputs": [ {
-                                                                                                          "address": 5316,
+                                                                                                          "address": 5310,
                                                                                                       "description": "selector position",
                                                                                                              "mask": 16,
                                                                                                         "max_value": 1,
@@ -3485,7 +3485,7 @@
                                                                                                       } ],
                                                                                "momentary_positions": "none",
                                                                                            "outputs": [ {
-                                                                                                              "address": 5410,
+                                                                                                              "address": 5404,
                                                                                                           "description": "selector position",
                                                                                                                  "mask": 2,
                                                                                                             "max_value": 1,
@@ -3514,7 +3514,7 @@
                                                                                                       } ],
                                                                                "momentary_positions": "none",
                                                                                            "outputs": [ {
-                                                                                                              "address": 5402,
+                                                                                                              "address": 5396,
                                                                                                           "description": "selector position",
                                                                                                                  "mask": 16384,
                                                                                                             "max_value": 1,
@@ -3537,18 +3537,16 @@
                                                                            },
                                                     "CM_CHAFFCNT_DISPLAY": {
                                                                                    "category": "Countermeasures",
-                                                                               "control_type": "metadata",
-                                                                                "description": "Chaff Counter Display",
+                                                                               "control_type": "display",
+                                                                                "description": "Chaff Counter",
                                                                                  "identifier": "CM_CHAFFCNT_DISPLAY",
                                                                                      "inputs": [  ],
                                                                                     "outputs": [ {
-                                                                                                       "address": 5410,
-                                                                                                   "description": "Chaff Counter Display",
-                                                                                                          "mask": 64512,
-                                                                                                     "max_value": 60,
-                                                                                                      "shift_by": 10,
+                                                                                                       "address": 5408,
+                                                                                                   "description": "Chaff Counter",
+                                                                                                    "max_length": 2,
                                                                                                         "suffix": "",
-                                                                                                          "type": "integer"
+                                                                                                          "type": "string"
                                                                                                } ]
                                                                            },
                                                       "CM_CHAFFCNT_RESET": {
@@ -3571,11 +3569,11 @@
                                                                                                       } ],
                                                                                "momentary_positions": "none",
                                                                                            "outputs": [ {
-                                                                                                              "address": 5410,
+                                                                                                              "address": 5404,
                                                                                                           "description": "selector position",
-                                                                                                                 "mask": 512,
+                                                                                                                 "mask": 8,
                                                                                                             "max_value": 1,
-                                                                                                             "shift_by": 9,
+                                                                                                             "shift_by": 3,
                                                                                                                "suffix": "",
                                                                                                                  "type": "integer"
                                                                                                       } ],
@@ -3594,18 +3592,16 @@
                                                                            },
                                                     "CM_FLARECNT_DISPLAY": {
                                                                                    "category": "Countermeasures",
-                                                                               "control_type": "metadata",
-                                                                                "description": "Flare Counter Display",
+                                                                               "control_type": "display",
+                                                                                "description": "Flare Counter",
                                                                                  "identifier": "CM_FLARECNT_DISPLAY",
                                                                                      "inputs": [  ],
                                                                                     "outputs": [ {
-                                                                                                       "address": 5410,
-                                                                                                   "description": "Flare Counter Display",
-                                                                                                          "mask": 504,
-                                                                                                     "max_value": 60,
-                                                                                                      "shift_by": 3,
+                                                                                                       "address": 5406,
+                                                                                                   "description": "Flare Counter",
+                                                                                                    "max_length": 2,
                                                                                                         "suffix": "",
-                                                                                                          "type": "integer"
+                                                                                                          "type": "string"
                                                                                                } ]
                                                                            },
                                                       "CM_FLARECNT_RESET": {
@@ -3628,7 +3624,7 @@
                                                                                                       } ],
                                                                                "momentary_positions": "none",
                                                                                            "outputs": [ {
-                                                                                                              "address": 5410,
+                                                                                                              "address": 5404,
                                                                                                           "description": "selector position",
                                                                                                                  "mask": 4,
                                                                                                             "max_value": 1,
@@ -3658,7 +3654,7 @@
                                                                                                       } ],
                                                                                "momentary_positions": "none",
                                                                                            "outputs": [ {
-                                                                                                              "address": 5410,
+                                                                                                              "address": 5404,
                                                                                                           "description": "selector position",
                                                                                                                  "mask": 1,
                                                                                                             "max_value": 1,
@@ -3687,7 +3683,7 @@
                                                                                                       } ],
                                                                                "momentary_positions": "none",
                                                                                            "outputs": [ {
-                                                                                                              "address": 5402,
+                                                                                                              "address": 5396,
                                                                                                           "description": "selector position",
                                                                                                                  "mask": 32768,
                                                                                                             "max_value": 1,
@@ -3716,7 +3712,7 @@
                                                                                                       } ],
                                                                                "momentary_positions": "none",
                                                                                            "outputs": [ {
-                                                                                                              "address": 5402,
+                                                                                                              "address": 5396,
                                                                                                           "description": "selector position",
                                                                                                                  "mask": 4096,
                                                                                                             "max_value": 1,
@@ -3745,7 +3741,7 @@
                                                                                                       } ],
                                                                                "momentary_positions": "none",
                                                                                            "outputs": [ {
-                                                                                                              "address": 5402,
+                                                                                                              "address": 5396,
                                                                                                           "description": "selector position",
                                                                                                                  "mask": 8192,
                                                                                                             "max_value": 1,
@@ -3890,7 +3886,7 @@
                                                                                                } ],
                                                                         "momentary_positions": "none",
                                                                                     "outputs": [ {
-                                                                                                       "address": 5344,
+                                                                                                       "address": 5338,
                                                                                                    "description": "selector position",
                                                                                                           "mask": 2048,
                                                                                                      "max_value": 1,
@@ -3920,7 +3916,7 @@
                                                                                                } ],
                                                                         "momentary_positions": "none",
                                                                                     "outputs": [ {
-                                                                                                       "address": 5402,
+                                                                                                       "address": 5396,
                                                                                                    "description": "selector position",
                                                                                                           "mask": 2048,
                                                                                                      "max_value": 1,
@@ -3950,7 +3946,7 @@
                                                                                                } ],
                                                                         "momentary_positions": "none",
                                                                                     "outputs": [ {
-                                                                                                       "address": 5402,
+                                                                                                       "address": 5396,
                                                                                                    "description": "selector position",
                                                                                                           "mask": 1024,
                                                                                                      "max_value": 1,
@@ -3982,11 +3978,11 @@
                                                                                              } ],
                                                                       "momentary_positions": "none",
                                                                                   "outputs": [ {
-                                                                                                     "address": 5412,
+                                                                                                     "address": 5404,
                                                                                                  "description": "selector position",
-                                                                                                        "mask": 8,
+                                                                                                        "mask": 128,
                                                                                                    "max_value": 1,
-                                                                                                    "shift_by": 3,
+                                                                                                    "shift_by": 7,
                                                                                                       "suffix": "",
                                                                                                         "type": "integer"
                                                                                              } ],
@@ -4012,11 +4008,11 @@
                                                                                              } ],
                                                                       "momentary_positions": "none",
                                                                                   "outputs": [ {
-                                                                                                     "address": 5412,
+                                                                                                     "address": 5404,
                                                                                                  "description": "selector position",
-                                                                                                        "mask": 16,
+                                                                                                        "mask": 256,
                                                                                                    "max_value": 1,
-                                                                                                    "shift_by": 4,
+                                                                                                    "shift_by": 8,
                                                                                                       "suffix": "",
                                                                                                         "type": "integer"
                                                                                              } ],
@@ -4039,7 +4035,7 @@
                                                                                                  } ],
                                                                           "momentary_positions": "none",
                                                                                       "outputs": [ {
-                                                                                                         "address": 5300,
+                                                                                                         "address": 5294,
                                                                                                      "description": "selector position",
                                                                                                             "mask": 24,
                                                                                                        "max_value": 2,
@@ -4093,7 +4089,7 @@
                                                                                                  } ],
                                                                           "momentary_positions": "none",
                                                                                       "outputs": [ {
-                                                                                                         "address": 5300,
+                                                                                                         "address": 5294,
                                                                                                      "description": "selector position",
                                                                                                             "mask": 7,
                                                                                                        "max_value": 4,
@@ -4118,7 +4114,7 @@
                                                                                                  } ],
                                                                           "momentary_positions": "none",
                                                                                       "outputs": [ {
-                                                                                                         "address": 5300,
+                                                                                                         "address": 5294,
                                                                                                      "description": "selector position",
                                                                                                             "mask": 96,
                                                                                                        "max_value": 2,
@@ -4207,7 +4203,7 @@
                                                                                                 } ],
                                                                          "momentary_positions": "none",
                                                                                      "outputs": [ {
-                                                                                                        "address": 5316,
+                                                                                                        "address": 5310,
                                                                                                     "description": "selector position",
                                                                                                            "mask": 512,
                                                                                                       "max_value": 1,
@@ -4236,7 +4232,7 @@
                                                                                                 } ],
                                                                          "momentary_positions": "none",
                                                                                      "outputs": [ {
-                                                                                                        "address": 5316,
+                                                                                                        "address": 5310,
                                                                                                     "description": "selector position",
                                                                                                            "mask": 32,
                                                                                                       "max_value": 1,
@@ -4265,7 +4261,7 @@
                                                                                                 } ],
                                                                          "momentary_positions": "none",
                                                                                      "outputs": [ {
-                                                                                                        "address": 5316,
+                                                                                                        "address": 5310,
                                                                                                     "description": "selector position",
                                                                                                            "mask": 64,
                                                                                                       "max_value": 1,
@@ -4284,11 +4280,11 @@
                                                                                       "identifier": "EXT_POSITION_LIGHT_LEFT",
                                                                                           "inputs": [  ],
                                                                                          "outputs": [ {
-                                                                                                            "address": 5412,
+                                                                                                            "address": 5404,
                                                                                                         "description": "Left Position Light (red)",
-                                                                                                               "mask": 32,
+                                                                                                               "mask": 512,
                                                                                                           "max_value": 1,
-                                                                                                           "shift_by": 5,
+                                                                                                           "shift_by": 9,
                                                                                                              "suffix": "",
                                                                                                                "type": "integer"
                                                                                                     } ]
@@ -4300,11 +4296,11 @@
                                                                                       "identifier": "EXT_POSITION_LIGHT_RIGHT",
                                                                                           "inputs": [  ],
                                                                                          "outputs": [ {
-                                                                                                            "address": 5412,
+                                                                                                            "address": 5404,
                                                                                                         "description": "Right Position Light (green)",
-                                                                                                               "mask": 64,
+                                                                                                               "mask": 1024,
                                                                                                           "max_value": 1,
-                                                                                                           "shift_by": 6,
+                                                                                                           "shift_by": 10,
                                                                                                              "suffix": "",
                                                                                                                "type": "integer"
                                                                                                     } ]
@@ -4316,11 +4312,11 @@
                                                                                       "identifier": "EXT_STROBE",
                                                                                           "inputs": [  ],
                                                                                          "outputs": [ {
-                                                                                                            "address": 5412,
+                                                                                                            "address": 5404,
                                                                                                         "description": "Strobe Light",
-                                                                                                               "mask": 128,
+                                                                                                               "mask": 2048,
                                                                                                           "max_value": 1,
-                                                                                                           "shift_by": 7,
+                                                                                                           "shift_by": 11,
                                                                                                              "suffix": "",
                                                                                                                "type": "integer"
                                                                                                     } ]
@@ -4346,7 +4342,7 @@
                                                                                                    } ],
                                                                             "momentary_positions": "none",
                                                                                         "outputs": [ {
-                                                                                                           "address": 5402,
+                                                                                                           "address": 5396,
                                                                                                        "description": "selector position",
                                                                                                               "mask": 8,
                                                                                                          "max_value": 1,
@@ -4372,7 +4368,7 @@
                                                                                                 "suggested_step": 3200
                                                                                             } ],
                                                                                  "outputs": [ {
-                                                                                                    "address": 5408,
+                                                                                                    "address": 5402,
                                                                                                 "description": "position of the potentiometer",
                                                                                                        "mask": 65535,
                                                                                                   "max_value": 65535,
@@ -4397,7 +4393,7 @@
                                                                                                 "suggested_step": 3200
                                                                                             } ],
                                                                                  "outputs": [ {
-                                                                                                    "address": 5404,
+                                                                                                    "address": 5398,
                                                                                                 "description": "position of the potentiometer",
                                                                                                        "mask": 65535,
                                                                                                   "max_value": 65535,
@@ -4422,7 +4418,7 @@
                                                                                                 "suggested_step": 3200
                                                                                             } ],
                                                                                  "outputs": [ {
-                                                                                                    "address": 5406,
+                                                                                                    "address": 5400,
                                                                                                 "description": "position of the potentiometer",
                                                                                                        "mask": 65535,
                                                                                                   "max_value": 65535,
@@ -4446,7 +4442,7 @@
                                                                                                    } ],
                                                                             "momentary_positions": "none",
                                                                                         "outputs": [ {
-                                                                                                           "address": 5402,
+                                                                                                           "address": 5396,
                                                                                                        "description": "selector position",
                                                                                                               "mask": 6,
                                                                                                          "max_value": 2,
@@ -4475,7 +4471,7 @@
                                                                                                    } ],
                                                                             "momentary_positions": "none",
                                                                                         "outputs": [ {
-                                                                                                           "address": 5402,
+                                                                                                           "address": 5396,
                                                                                                        "description": "selector position",
                                                                                                               "mask": 16,
                                                                                                          "max_value": 1,
@@ -4522,7 +4518,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5378,
+                                                                                                             "address": 5372,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 32768,
                                                                                                            "max_value": 1,
@@ -4544,7 +4540,7 @@
                                                                                                   "suggested_step": 3200
                                                                                               } ],
                                                                                    "outputs": [ {
-                                                                                                      "address": 5328,
+                                                                                                      "address": 5322,
                                                                                                   "description": "rotation of the knob (not the value being manipulated!)",
                                                                                                          "mask": 65535,
                                                                                                     "max_value": 65535,
@@ -4565,7 +4561,7 @@
                                                                                                   "suggested_step": 3200
                                                                                               } ],
                                                                                    "outputs": [ {
-                                                                                                      "address": 5326,
+                                                                                                      "address": 5320,
                                                                                                   "description": "rotation of the knob (not the value being manipulated!)",
                                                                                                          "mask": 65535,
                                                                                                     "max_value": 65535,
@@ -4587,7 +4583,7 @@
                                                                                                   "suggested_step": 3200
                                                                                               } ],
                                                                                    "outputs": [ {
-                                                                                                      "address": 5330,
+                                                                                                      "address": 5324,
                                                                                                   "description": "the rotation of the knob in the cockpit (not the value that is controlled by this knob!)",
                                                                                                          "mask": 65535,
                                                                                                     "max_value": 65535,
@@ -4609,7 +4605,7 @@
                                                                                                   "suggested_step": 3200
                                                                                               } ],
                                                                                    "outputs": [ {
-                                                                                                      "address": 5332,
+                                                                                                      "address": 5326,
                                                                                                   "description": "the rotation of the knob in the cockpit (not the value that is controlled by this knob!)",
                                                                                                          "mask": 65535,
                                                                                                     "max_value": 65535,
@@ -4637,7 +4633,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5362,
+                                                                                                             "address": 5356,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 256,
                                                                                                            "max_value": 1,
@@ -4663,7 +4659,7 @@
                                                                                                   "suggested_step": 3200
                                                                                               } ],
                                                                                    "outputs": [ {
-                                                                                                      "address": 5374,
+                                                                                                      "address": 5368,
                                                                                                   "description": "position of the potentiometer",
                                                                                                          "mask": 65535,
                                                                                                     "max_value": 65535,
@@ -4740,7 +4736,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5316,
+                                                                                                             "address": 5310,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 32768,
                                                                                                            "max_value": 1,
@@ -4763,7 +4759,7 @@
                                                                                                   "suggested_step": 3200
                                                                                               } ],
                                                                                    "outputs": [ {
-                                                                                                      "address": 5400,
+                                                                                                      "address": 5394,
                                                                                                   "description": "the rotation of the knob in the cockpit (not the value that is controlled by this knob!)",
                                                                                                          "mask": 65535,
                                                                                                     "max_value": 65535,
@@ -4888,7 +4884,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5316,
+                                                                                                             "address": 5310,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 16384,
                                                                                                            "max_value": 1,
@@ -4981,7 +4977,7 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5394,
+                                                                                                             "address": 5388,
                                                                                                          "description": "selector position",
                                                                                                                 "mask": 8,
                                                                                                            "max_value": 1,
@@ -4992,46 +4988,52 @@
                                                                                  "physical_variant": "toggle_switch"
                                                                           },
                                                                "HDG_SET": {
-                                                                               "api_variant": "multiturn",
                                                                                   "category": "Front Dash",
-                                                                              "control_type": "analog_dial",
+                                                                              "control_type": "limited_dial",
                                                                                "description": "HDG SET Knob",
                                                                                 "identifier": "HDG_SET",
                                                                                     "inputs": [ {
+                                                                                                  "description": "set the position of the dial",
+                                                                                                    "interface": "set_state",
+                                                                                                    "max_value": 65535
+                                                                                              }, {
                                                                                                      "description": "turn the dial left or right",
                                                                                                        "interface": "variable_step",
                                                                                                        "max_value": 65535,
                                                                                                   "suggested_step": 3200
                                                                                               } ],
                                                                                    "outputs": [ {
-                                                                                                      "address": 5396,
-                                                                                                  "description": "the rotation of the knob in the cockpit (not the value that is controlled by this knob!)",
+                                                                                                      "address": 5390,
+                                                                                                  "description": "position of the potentiometer",
                                                                                                          "mask": 65535,
                                                                                                     "max_value": 65535,
                                                                                                      "shift_by": 0,
-                                                                                                       "suffix": "_KNOB_POS",
+                                                                                                       "suffix": "",
                                                                                                          "type": "integer"
                                                                                               } ]
                                                                           },
                                                               "HDG_SYNC": {
-                                                                               "api_variant": "multiturn",
                                                                                   "category": "Front Dash",
-                                                                              "control_type": "analog_dial",
+                                                                              "control_type": "limited_dial",
                                                                                "description": "Compass Synchronizing",
                                                                                 "identifier": "HDG_SYNC",
                                                                                     "inputs": [ {
+                                                                                                  "description": "set the position of the dial",
+                                                                                                    "interface": "set_state",
+                                                                                                    "max_value": 65535
+                                                                                              }, {
                                                                                                      "description": "turn the dial left or right",
                                                                                                        "interface": "variable_step",
                                                                                                        "max_value": 65535,
                                                                                                   "suggested_step": 3200
                                                                                               } ],
                                                                                    "outputs": [ {
-                                                                                                      "address": 5398,
-                                                                                                  "description": "the rotation of the knob in the cockpit (not the value that is controlled by this knob!)",
+                                                                                                      "address": 5392,
+                                                                                                  "description": "position of the potentiometer",
                                                                                                          "mask": 65535,
                                                                                                     "max_value": 65535,
                                                                                                      "shift_by": 0,
-                                                                                                       "suffix": "_KNOB_POS",
+                                                                                                       "suffix": "",
                                                                                                          "type": "integer"
                                                                                               } ]
                                                                           },
@@ -5096,7 +5098,7 @@
                                                                                                   "suggested_step": 3200
                                                                                               } ],
                                                                                    "outputs": [ {
-                                                                                                      "address": 5416,
+                                                                                                      "address": 5412,
                                                                                                   "description": "the rotation of the knob in the cockpit (not the value that is controlled by this knob!)",
                                                                                                          "mask": 65535,
                                                                                                     "max_value": 65535,
@@ -5118,7 +5120,7 @@
                                                                                                   "suggested_step": 3200
                                                                                               } ],
                                                                                    "outputs": [ {
-                                                                                                      "address": 5414,
+                                                                                                      "address": 5410,
                                                                                                   "description": "the rotation of the knob in the cockpit (not the value that is controlled by this knob!)",
                                                                                                          "mask": 65535,
                                                                                                     "max_value": 65535,
@@ -5147,11 +5149,11 @@
                                                                                                      } ],
                                                                               "momentary_positions": "none",
                                                                                           "outputs": [ {
-                                                                                                             "address": 5412,
+                                                                                                             "address": 5404,
                                                                                                          "description": "selector position",
-                                                                                                                "mask": 2,
+                                                                                                                "mask": 32,
                                                                                                            "max_value": 1,
-                                                                                                            "shift_by": 1,
+                                                                                                            "shift_by": 5,
                                                                                                               "suffix": "",
                                                                                                                 "type": "integer"
                                                                                                      } ],
@@ -5422,7 +5424,7 @@
                                                                                                       } ],
                                                                                "momentary_positions": "none",
                                                                                            "outputs": [ {
-                                                                                                              "address": 5310,
+                                                                                                              "address": 5304,
                                                                                                           "description": "selector position",
                                                                                                                  "mask": 1024,
                                                                                                             "max_value": 1,
@@ -5452,7 +5454,7 @@
                                                                                                       } ],
                                                                                "momentary_positions": "none",
                                                                                            "outputs": [ {
-                                                                                                              "address": 5310,
+                                                                                                              "address": 5304,
                                                                                                           "description": "selector position",
                                                                                                                  "mask": 2048,
                                                                                                             "max_value": 1,
@@ -5575,7 +5577,7 @@
                                                                                                       } ],
                                                                                "momentary_positions": "none",
                                                                                            "outputs": [ {
-                                                                                                              "address": 5310,
+                                                                                                              "address": 5304,
                                                                                                           "description": "selector position",
                                                                                                                  "mask": 12288,
                                                                                                             "max_value": 3,
@@ -5600,7 +5602,7 @@
                                                                                                       } ],
                                                                                "momentary_positions": "none",
                                                                                            "outputs": [ {
-                                                                                                              "address": 5312,
+                                                                                                              "address": 5306,
                                                                                                           "description": "selector position",
                                                                                                                  "mask": 7,
                                                                                                             "max_value": 4,
@@ -5625,7 +5627,7 @@
                                                                                                       } ],
                                                                                "momentary_positions": "none",
                                                                                            "outputs": [ {
-                                                                                                              "address": 5312,
+                                                                                                              "address": 5306,
                                                                                                           "description": "selector position",
                                                                                                                  "mask": 24576,
                                                                                                             "max_value": 2,
@@ -5650,7 +5652,7 @@
                                                                                                       } ],
                                                                                "momentary_positions": "none",
                                                                                            "outputs": [ {
-                                                                                                              "address": 5314,
+                                                                                                              "address": 5308,
                                                                                                           "description": "selector position",
                                                                                                                  "mask": 7,
                                                                                                             "max_value": 7,
@@ -5675,7 +5677,7 @@
                                                                                                       } ],
                                                                                "momentary_positions": "none",
                                                                                            "outputs": [ {
-                                                                                                              "address": 5314,
+                                                                                                              "address": 5308,
                                                                                                           "description": "selector position",
                                                                                                                  "mask": 24,
                                                                                                             "max_value": 3,
@@ -5700,7 +5702,7 @@
                                                                                                       } ],
                                                                                "momentary_positions": "none",
                                                                                            "outputs": [ {
-                                                                                                              "address": 5314,
+                                                                                                              "address": 5308,
                                                                                                           "description": "selector position",
                                                                                                                  "mask": 224,
                                                                                                             "max_value": 7,
@@ -5725,7 +5727,7 @@
                                                                                                       } ],
                                                                                "momentary_positions": "none",
                                                                                            "outputs": [ {
-                                                                                                              "address": 5314,
+                                                                                                              "address": 5308,
                                                                                                           "description": "selector position",
                                                                                                                  "mask": 1792,
                                                                                                             "max_value": 7,
@@ -5750,7 +5752,7 @@
                                                                                                       } ],
                                                                                "momentary_positions": "none",
                                                                                            "outputs": [ {
-                                                                                                              "address": 5314,
+                                                                                                              "address": 5308,
                                                                                                           "description": "selector position",
                                                                                                                  "mask": 14336,
                                                                                                             "max_value": 7,
@@ -5775,7 +5777,7 @@
                                                                                                       } ],
                                                                                "momentary_positions": "none",
                                                                                            "outputs": [ {
-                                                                                                              "address": 5316,
+                                                                                                              "address": 5310,
                                                                                                           "description": "selector position",
                                                                                                                  "mask": 7,
                                                                                                             "max_value": 7,
@@ -5804,7 +5806,7 @@
                                                                                                       } ],
                                                                                "momentary_positions": "none",
                                                                                            "outputs": [ {
-                                                                                                              "address": 5312,
+                                                                                                              "address": 5306,
                                                                                                           "description": "selector position",
                                                                                                                  "mask": 32768,
                                                                                                             "max_value": 1,
@@ -5829,7 +5831,7 @@
                                                                                                       } ],
                                                                                "momentary_positions": "none",
                                                                                            "outputs": [ {
-                                                                                                              "address": 5310,
+                                                                                                              "address": 5304,
                                                                                                           "description": "selector position",
                                                                                                                  "mask": 49152,
                                                                                                             "max_value": 2,
@@ -5854,7 +5856,7 @@
                                                                                                       } ],
                                                                                "momentary_positions": "none",
                                                                                            "outputs": [ {
-                                                                                                              "address": 5312,
+                                                                                                              "address": 5306,
                                                                                                           "description": "selector position",
                                                                                                                  "mask": 6144,
                                                                                                             "max_value": 2,
@@ -5880,7 +5882,7 @@
                                                                                                    "suggested_step": 3200
                                                                                                } ],
                                                                                     "outputs": [ {
-                                                                                                       "address": 5318,
+                                                                                                       "address": 5312,
                                                                                                    "description": "position of the potentiometer",
                                                                                                           "mask": 65535,
                                                                                                      "max_value": 65535,
@@ -5925,7 +5927,7 @@
                                                                                                       } ],
                                                                                "momentary_positions": "none",
                                                                                            "outputs": [ {
-                                                                                                              "address": 5314,
+                                                                                                              "address": 5308,
                                                                                                           "description": "selector position",
                                                                                                                  "mask": 16384,
                                                                                                             "max_value": 1,
@@ -5951,7 +5953,7 @@
                                                                                                    "suggested_step": 3200
                                                                                                } ],
                                                                                     "outputs": [ {
-                                                                                                       "address": 5320,
+                                                                                                       "address": 5314,
                                                                                                    "description": "position of the potentiometer",
                                                                                                           "mask": 65535,
                                                                                                      "max_value": 65535,
@@ -5991,7 +5993,7 @@
                                                                                                       } ],
                                                                                "momentary_positions": "none",
                                                                                            "outputs": [ {
-                                                                                                              "address": 5312,
+                                                                                                              "address": 5306,
                                                                                                           "description": "selector position",
                                                                                                                  "mask": 24,
                                                                                                             "max_value": 2,
@@ -6016,7 +6018,7 @@
                                                                                                       } ],
                                                                                "momentary_positions": "none",
                                                                                            "outputs": [ {
-                                                                                                              "address": 5312,
+                                                                                                              "address": 5306,
                                                                                                           "description": "selector position",
                                                                                                                  "mask": 96,
                                                                                                             "max_value": 2,
@@ -6041,7 +6043,7 @@
                                                                                                       } ],
                                                                                "momentary_positions": "none",
                                                                                            "outputs": [ {
-                                                                                                              "address": 5312,
+                                                                                                              "address": 5306,
                                                                                                           "description": "selector position",
                                                                                                                  "mask": 384,
                                                                                                             "max_value": 2,
@@ -6066,7 +6068,7 @@
                                                                                                       } ],
                                                                                "momentary_positions": "none",
                                                                                            "outputs": [ {
-                                                                                                              "address": 5312,
+                                                                                                              "address": 5306,
                                                                                                           "description": "selector position",
                                                                                                                  "mask": 1536,
                                                                                                             "max_value": 2,
@@ -6096,7 +6098,7 @@
                                                                                                       } ],
                                                                                "momentary_positions": "none",
                                                                                            "outputs": [ {
-                                                                                                              "address": 5314,
+                                                                                                              "address": 5308,
                                                                                                           "description": "selector position",
                                                                                                                  "mask": 32768,
                                                                                                             "max_value": 1,
@@ -6122,7 +6124,7 @@
                                                                                            } ],
                                                                     "momentary_positions": "none",
                                                                                 "outputs": [ {
-                                                                                                   "address": 5344,
+                                                                                                   "address": 5338,
                                                                                                "description": "selector position",
                                                                                                       "mask": 1792,
                                                                                                  "max_value": 5,
@@ -6153,7 +6155,7 @@
                                                                                                 } ],
                                                                          "momentary_positions": "none",
                                                                                      "outputs": [ {
-                                                                                                        "address": 5334,
+                                                                                                        "address": 5328,
                                                                                                     "description": "selector position",
                                                                                                            "mask": 16384,
                                                                                                       "max_value": 1,
@@ -6182,7 +6184,7 @@
                                                                                                 } ],
                                                                          "momentary_positions": "none",
                                                                                      "outputs": [ {
-                                                                                                        "address": 5334,
+                                                                                                        "address": 5328,
                                                                                                     "description": "selector position",
                                                                                                            "mask": 32768,
                                                                                                       "max_value": 1,
@@ -6211,7 +6213,7 @@
                                                                                                 } ],
                                                                          "momentary_positions": "none",
                                                                                      "outputs": [ {
-                                                                                                        "address": 5334,
+                                                                                                        "address": 5328,
                                                                                                     "description": "selector position",
                                                                                                            "mask": 1024,
                                                                                                       "max_value": 1,
@@ -6240,7 +6242,7 @@
                                                                                                 } ],
                                                                          "momentary_positions": "none",
                                                                                      "outputs": [ {
-                                                                                                        "address": 5334,
+                                                                                                        "address": 5328,
                                                                                                     "description": "selector position",
                                                                                                            "mask": 2048,
                                                                                                       "max_value": 1,
@@ -6269,7 +6271,7 @@
                                                                                                 } ],
                                                                          "momentary_positions": "none",
                                                                                      "outputs": [ {
-                                                                                                        "address": 5334,
+                                                                                                        "address": 5328,
                                                                                                     "description": "selector position",
                                                                                                            "mask": 4096,
                                                                                                       "max_value": 1,
@@ -6298,7 +6300,7 @@
                                                                                                 } ],
                                                                          "momentary_positions": "none",
                                                                                      "outputs": [ {
-                                                                                                        "address": 5334,
+                                                                                                        "address": 5328,
                                                                                                     "description": "selector position",
                                                                                                            "mask": 8192,
                                                                                                       "max_value": 1,
@@ -6324,7 +6326,7 @@
                                                                                              "suggested_step": 3200
                                                                                          } ],
                                                                               "outputs": [ {
-                                                                                                 "address": 5346,
+                                                                                                 "address": 5340,
                                                                                              "description": "position of the potentiometer",
                                                                                                     "mask": 65535,
                                                                                                "max_value": 65535,
@@ -6404,7 +6406,7 @@
                                                                                                   } ],
                                                                            "momentary_positions": "none",
                                                                                        "outputs": [ {
-                                                                                                          "address": 5378,
+                                                                                                          "address": 5372,
                                                                                                       "description": "selector position",
                                                                                                              "mask": 128,
                                                                                                         "max_value": 1,
@@ -6429,7 +6431,7 @@
                                                                                                   } ],
                                                                            "momentary_positions": "none",
                                                                                        "outputs": [ {
-                                                                                                          "address": 5394,
+                                                                                                          "address": 5388,
                                                                                                       "description": "selector position",
                                                                                                              "mask": 7,
                                                                                                         "max_value": 4,
@@ -6455,7 +6457,7 @@
                                                                                                "suggested_step": 3200
                                                                                            } ],
                                                                                 "outputs": [ {
-                                                                                                   "address": 5382,
+                                                                                                   "address": 5376,
                                                                                                "description": "position of the potentiometer",
                                                                                                       "mask": 65535,
                                                                                                  "max_value": 65535,
@@ -6480,7 +6482,7 @@
                                                                                                "suggested_step": 3200
                                                                                            } ],
                                                                                 "outputs": [ {
-                                                                                                   "address": 5390,
+                                                                                                   "address": 5384,
                                                                                                "description": "position of the potentiometer",
                                                                                                       "mask": 65535,
                                                                                                  "max_value": 65535,
@@ -6505,7 +6507,7 @@
                                                                                                "suggested_step": 3200
                                                                                            } ],
                                                                                 "outputs": [ {
-                                                                                                   "address": 5388,
+                                                                                                   "address": 5382,
                                                                                                "description": "position of the potentiometer",
                                                                                                       "mask": 65535,
                                                                                                  "max_value": 65535,
@@ -6530,7 +6532,7 @@
                                                                                                "suggested_step": 3200
                                                                                            } ],
                                                                                 "outputs": [ {
-                                                                                                   "address": 5384,
+                                                                                                   "address": 5378,
                                                                                                "description": "position of the potentiometer",
                                                                                                       "mask": 65535,
                                                                                                  "max_value": 65535,
@@ -6555,7 +6557,7 @@
                                                                                                "suggested_step": 3200
                                                                                            } ],
                                                                                 "outputs": [ {
-                                                                                                   "address": 5392,
+                                                                                                   "address": 5386,
                                                                                                "description": "position of the potentiometer",
                                                                                                       "mask": 65535,
                                                                                                  "max_value": 65535,
@@ -6580,7 +6582,7 @@
                                                                                                "suggested_step": 3200
                                                                                            } ],
                                                                                 "outputs": [ {
-                                                                                                   "address": 5386,
+                                                                                                   "address": 5380,
                                                                                                "description": "position of the potentiometer",
                                                                                                       "mask": 65535,
                                                                                                  "max_value": 65535,
@@ -6604,7 +6606,7 @@
                                                                                                   } ],
                                                                            "momentary_positions": "none",
                                                                                        "outputs": [ {
-                                                                                                          "address": 5378,
+                                                                                                          "address": 5372,
                                                                                                       "description": "selector position",
                                                                                                              "mask": 24576,
                                                                                                         "max_value": 2,
@@ -6633,7 +6635,7 @@
                                                                                                   } ],
                                                                            "momentary_positions": "none",
                                                                                        "outputs": [ {
-                                                                                                          "address": 5310,
+                                                                                                          "address": 5304,
                                                                                                       "description": "selector position",
                                                                                                              "mask": 32,
                                                                                                         "max_value": 1,
@@ -6658,7 +6660,7 @@
                                                                                                   } ],
                                                                            "momentary_positions": "none",
                                                                                        "outputs": [ {
-                                                                                                          "address": 5310,
+                                                                                                          "address": 5304,
                                                                                                       "description": "selector position",
                                                                                                              "mask": 24,
                                                                                                         "max_value": 2,
@@ -6683,7 +6685,7 @@
                                                                                                   } ],
                                                                            "momentary_positions": "none",
                                                                                        "outputs": [ {
-                                                                                                          "address": 5378,
+                                                                                                          "address": 5372,
                                                                                                       "description": "selector position",
                                                                                                              "mask": 96,
                                                                                                         "max_value": 2,
@@ -6708,7 +6710,7 @@
                                                                                                   } ],
                                                                            "momentary_positions": "none",
                                                                                        "outputs": [ {
-                                                                                                          "address": 5378,
+                                                                                                          "address": 5372,
                                                                                                       "description": "selector position",
                                                                                                              "mask": 28,
                                                                                                         "max_value": 5,
@@ -6737,7 +6739,7 @@
                                                                                                   } ],
                                                                            "momentary_positions": "none",
                                                                                        "outputs": [ {
-                                                                                                          "address": 5310,
+                                                                                                          "address": 5304,
                                                                                                       "description": "selector position",
                                                                                                              "mask": 4,
                                                                                                         "max_value": 1,
@@ -6766,7 +6768,7 @@
                                                                                                   } ],
                                                                            "momentary_positions": "none",
                                                                                        "outputs": [ {
-                                                                                                          "address": 5362,
+                                                                                                          "address": 5356,
                                                                                                       "description": "selector position",
                                                                                                              "mask": 32768,
                                                                                                         "max_value": 1,
@@ -6795,11 +6797,11 @@
                                                                                                   } ],
                                                                            "momentary_positions": "none",
                                                                                        "outputs": [ {
-                                                                                                          "address": 5412,
+                                                                                                          "address": 5404,
                                                                                                       "description": "selector position",
-                                                                                                             "mask": 1,
+                                                                                                             "mask": 16,
                                                                                                         "max_value": 1,
-                                                                                                         "shift_by": 0,
+                                                                                                         "shift_by": 4,
                                                                                                            "suffix": "",
                                                                                                              "type": "integer"
                                                                                                   } ],
@@ -6820,7 +6822,7 @@
                                                                                                   } ],
                                                                            "momentary_positions": "none",
                                                                                        "outputs": [ {
-                                                                                                          "address": 5402,
+                                                                                                          "address": 5396,
                                                                                                       "description": "selector position",
                                                                                                              "mask": 96,
                                                                                                         "max_value": 2,
@@ -6841,7 +6843,7 @@
                                                                                                   } ],
                                                                            "momentary_positions": "none",
                                                                                        "outputs": [ {
-                                                                                                          "address": 5402,
+                                                                                                          "address": 5396,
                                                                                                       "description": "selector position",
                                                                                                              "mask": 896,
                                                                                                         "max_value": 4,
@@ -6853,84 +6855,18 @@
                                                                        }
                                                 },
                              "Radar Altimeter": {
-                                                    "RALT_DIGIT_1": {
-                                                                            "category": "Radar Altimeter",
-                                                                        "control_type": "analog_gauge",
-                                                                         "description": "Radar Altimeter 1.Digit",
-                                                                          "identifier": "RALT_DIGIT_1",
-                                                                              "inputs": [  ],
-                                                                             "outputs": [ {
-                                                                                                "address": 5292,
-                                                                                            "description": "gauge position",
-                                                                                                   "mask": 65535,
-                                                                                              "max_value": 65535,
-                                                                                               "shift_by": 0,
-                                                                                                 "suffix": "",
-                                                                                                   "type": "integer"
-                                                                                        } ]
-                                                                    },
-                                                    "RALT_DIGIT_2": {
-                                                                            "category": "Radar Altimeter",
-                                                                        "control_type": "analog_gauge",
-                                                                         "description": "Radar Altimeter 2.Digit",
-                                                                          "identifier": "RALT_DIGIT_2",
-                                                                              "inputs": [  ],
-                                                                             "outputs": [ {
-                                                                                                "address": 5294,
-                                                                                            "description": "gauge position",
-                                                                                                   "mask": 65535,
-                                                                                              "max_value": 65535,
-                                                                                               "shift_by": 0,
-                                                                                                 "suffix": "",
-                                                                                                   "type": "integer"
-                                                                                        } ]
-                                                                    },
-                                                    "RALT_DIGIT_3": {
-                                                                            "category": "Radar Altimeter",
-                                                                        "control_type": "analog_gauge",
-                                                                         "description": "Radar Altimeter 3.Digit",
-                                                                          "identifier": "RALT_DIGIT_3",
-                                                                              "inputs": [  ],
-                                                                             "outputs": [ {
-                                                                                                "address": 5296,
-                                                                                            "description": "gauge position",
-                                                                                                   "mask": 65535,
-                                                                                              "max_value": 65535,
-                                                                                               "shift_by": 0,
-                                                                                                 "suffix": "",
-                                                                                                   "type": "integer"
-                                                                                        } ]
-                                                                    },
-                                                    "RALT_DIGIT_4": {
-                                                                            "category": "Radar Altimeter",
-                                                                        "control_type": "analog_gauge",
-                                                                         "description": "Radar Altimeter 4.Digit",
-                                                                          "identifier": "RALT_DIGIT_4",
-                                                                              "inputs": [  ],
-                                                                             "outputs": [ {
-                                                                                                "address": 5298,
-                                                                                            "description": "gauge position",
-                                                                                                   "mask": 65535,
-                                                                                              "max_value": 65535,
-                                                                                               "shift_by": 0,
-                                                                                                 "suffix": "",
-                                                                                                   "type": "integer"
-                                                                                        } ]
-                                                                    },
                                                     "RALT_DISPLAY": {
                                                                             "category": "Radar Altimeter",
-                                                                        "control_type": "metadata",
-                                                                         "description": "Radar Altitude Display",
+                                                                        "control_type": "display",
+                                                                         "description": "Display",
                                                                           "identifier": "RALT_DISPLAY",
                                                                               "inputs": [  ],
                                                                              "outputs": [ {
                                                                                                 "address": 5290,
-                                                                                            "description": "Radar Altitude Display",
-                                                                                                   "mask": 65535,
-                                                                                              "max_value": 65000,
-                                                                                               "shift_by": 0,
+                                                                                            "description": "Display",
+                                                                                             "max_length": 4,
                                                                                                  "suffix": "",
-                                                                                                   "type": "integer"
+                                                                                                   "type": "string"
                                                                                         } ]
                                                                     },
                                                      "RALT_HI_IDX": {
@@ -7071,7 +7007,7 @@
                                                                             "identifier": "UHF_FREQ",
                                                                                 "inputs": [  ],
                                                                                "outputs": [ {
-                                                                                                  "address": 5352,
+                                                                                                  "address": 5346,
                                                                                               "description": "UHF Frequency",
                                                                                                "max_length": 6,
                                                                                                    "suffix": "",
@@ -7093,7 +7029,7 @@
                                                                                                  } ],
                                                                           "momentary_positions": "none",
                                                                                       "outputs": [ {
-                                                                                                         "address": 5344,
+                                                                                                         "address": 5338,
                                                                                                      "description": "selector position",
                                                                                                             "mask": 49152,
                                                                                                        "max_value": 3,
@@ -7118,7 +7054,7 @@
                                                                                                  } ],
                                                                           "momentary_positions": "none",
                                                                                       "outputs": [ {
-                                                                                                         "address": 5344,
+                                                                                                         "address": 5338,
                                                                                                      "description": "selector position",
                                                                                                             "mask": 12288,
                                                                                                        "max_value": 2,
@@ -7143,7 +7079,7 @@
                                                                                                  } ],
                                                                           "momentary_positions": "none",
                                                                                       "outputs": [ {
-                                                                                                         "address": 5348,
+                                                                                                         "address": 5342,
                                                                                                      "description": "selector position",
                                                                                                             "mask": 31,
                                                                                                        "max_value": 19,
@@ -7151,7 +7087,7 @@
                                                                                                           "suffix": "_INT",
                                                                                                             "type": "integer"
                                                                                                  }, {
-                                                                                                         "address": 5350,
+                                                                                                         "address": 5344,
                                                                                                      "description": "possible values: \"1\" \"2\" \"3\" \"4\" \"5\" \"6\" \"7\" \"8\" \"9\" \"10\" \"11\" \"12\" \"13\" \"14\" \"15\" \"16\" \"17\" \"18\" \"19\" \"20\" ",
                                                                                                       "max_length": 2,
                                                                                                           "suffix": "_STR",
@@ -7178,7 +7114,7 @@
                                                                                                  } ],
                                                                           "momentary_positions": "none",
                                                                                       "outputs": [ {
-                                                                                                         "address": 5348,
+                                                                                                         "address": 5342,
                                                                                                      "description": "selector position",
                                                                                                             "mask": 32,
                                                                                                        "max_value": 1,
@@ -7204,7 +7140,7 @@
                                                                                               "suggested_step": 3200
                                                                                           } ],
                                                                                "outputs": [ {
-                                                                                                  "address": 5358,
+                                                                                                  "address": 5352,
                                                                                               "description": "position of the potentiometer",
                                                                                                      "mask": 65535,
                                                                                                 "max_value": 65535,
@@ -7222,7 +7158,7 @@
                                                                              "identifier": "VHFCOMM_FREQ",
                                                                                  "inputs": [  ],
                                                                                 "outputs": [ {
-                                                                                                   "address": 5338,
+                                                                                                   "address": 5332,
                                                                                                "description": "VHF Frequency",
                                                                                                 "max_length": 7,
                                                                                                     "suffix": "",
@@ -7240,7 +7176,7 @@
                                                                                                   } ],
                                                                            "momentary_positions": "none",
                                                                                        "outputs": [ {
-                                                                                                          "address": 5334,
+                                                                                                          "address": 5328,
                                                                                                       "description": "selector position",
                                                                                                              "mask": 960,
                                                                                                         "max_value": 10,
@@ -7261,7 +7197,7 @@
                                                                                                   } ],
                                                                            "momentary_positions": "none",
                                                                                        "outputs": [ {
-                                                                                                          "address": 5334,
+                                                                                                          "address": 5328,
                                                                                                       "description": "selector position",
                                                                                                              "mask": 60,
                                                                                                         "max_value": 10,
@@ -7290,7 +7226,7 @@
                                                                                                   } ],
                                                                            "momentary_positions": "none",
                                                                                        "outputs": [ {
-                                                                                                          "address": 5334,
+                                                                                                          "address": 5328,
                                                                                                       "description": "selector position",
                                                                                                              "mask": 2,
                                                                                                         "max_value": 1,
@@ -7320,7 +7256,7 @@
                                                                                                   } ],
                                                                            "momentary_positions": "none",
                                                                                        "outputs": [ {
-                                                                                                          "address": 5334,
+                                                                                                          "address": 5328,
                                                                                                       "description": "selector position",
                                                                                                              "mask": 1,
                                                                                                         "max_value": 1,
@@ -7346,7 +7282,7 @@
                                                                                                "suggested_step": 8192
                                                                                            } ],
                                                                                 "outputs": [ {
-                                                                                                   "address": 5336,
+                                                                                                   "address": 5330,
                                                                                                "description": "position of the potentiometer",
                                                                                                       "mask": 65535,
                                                                                                  "max_value": 65535,
@@ -7372,7 +7308,7 @@
                                                                                                 } ],
                                                                          "momentary_positions": "none",
                                                                                      "outputs": [ {
-                                                                                                        "address": 5348,
+                                                                                                        "address": 5342,
                                                                                                     "description": "selector position",
                                                                                                            "mask": 448,
                                                                                                       "max_value": 4,
@@ -7380,7 +7316,7 @@
                                                                                                          "suffix": "_INT",
                                                                                                            "type": "integer"
                                                                                                 }, {
-                                                                                                        "address": 5360,
+                                                                                                        "address": 5354,
                                                                                                     "description": "possible values: \"3\" \"4\" \"5\" \"6\" \"7\" ",
                                                                                                      "max_length": 1,
                                                                                                          "suffix": "_STR",
@@ -7403,7 +7339,7 @@
                                                                                                 } ],
                                                                          "momentary_positions": "none",
                                                                                      "outputs": [ {
-                                                                                                        "address": 5348,
+                                                                                                        "address": 5342,
                                                                                                     "description": "selector position",
                                                                                                            "mask": 7680,
                                                                                                       "max_value": 9,
@@ -7428,7 +7364,7 @@
                                                                                                 } ],
                                                                          "momentary_positions": "none",
                                                                                      "outputs": [ {
-                                                                                                        "address": 5360,
+                                                                                                        "address": 5354,
                                                                                                     "description": "selector position",
                                                                                                            "mask": 3840,
                                                                                                       "max_value": 9,
@@ -7457,7 +7393,7 @@
                                                                                                 } ],
                                                                          "momentary_positions": "none",
                                                                                      "outputs": [ {
-                                                                                                        "address": 5348,
+                                                                                                        "address": 5342,
                                                                                                     "description": "selector position",
                                                                                                            "mask": 8192,
                                                                                                       "max_value": 1,
@@ -7465,7 +7401,7 @@
                                                                                                          "suffix": "_INT",
                                                                                                            "type": "integer"
                                                                                                 }, {
-                                                                                                        "address": 5362,
+                                                                                                        "address": 5356,
                                                                                                     "description": "possible values: \"0\" \"5\" ",
                                                                                                      "max_length": 1,
                                                                                                          "suffix": "_STR",
@@ -7488,7 +7424,7 @@
                                                                                                 } ],
                                                                          "momentary_positions": "none",
                                                                                      "outputs": [ {
-                                                                                                        "address": 5348,
+                                                                                                        "address": 5342,
                                                                                                     "description": "selector position",
                                                                                                            "mask": 49152,
                                                                                                       "max_value": 3,
@@ -7513,7 +7449,7 @@
                                                                                                 } ],
                                                                          "momentary_positions": "none",
                                                                                      "outputs": [ {
-                                                                                                        "address": 5360,
+                                                                                                        "address": 5354,
                                                                                                     "description": "selector position",
                                                                                                            "mask": 12288,
                                                                                                       "max_value": 2,
@@ -7539,7 +7475,7 @@
                                                                                              "suggested_step": 3200
                                                                                          } ],
                                                                               "outputs": [ {
-                                                                                                 "address": 5364,
+                                                                                                 "address": 5358,
                                                                                              "description": "position of the potentiometer",
                                                                                                     "mask": 65535,
                                                                                                "max_value": 65535,
@@ -7557,7 +7493,7 @@
                                                                          "identifier": "VHFNAV_FREQ",
                                                                              "inputs": [  ],
                                                                             "outputs": [ {
-                                                                                               "address": 5366,
+                                                                                               "address": 5360,
                                                                                            "description": "VHF NAV Frequency",
                                                                                             "max_length": 6,
                                                                                                 "suffix": "",
@@ -7601,7 +7537,7 @@
                                                                                               } ],
                                                                        "momentary_positions": "none",
                                                                                    "outputs": [ {
-                                                                                                      "address": 5360,
+                                                                                                      "address": 5354,
                                                                                                   "description": "selector position",
                                                                                                          "mask": 49152,
                                                                                                     "max_value": 2,
@@ -7627,7 +7563,7 @@
                                                                                            "suggested_step": 8192
                                                                                        } ],
                                                                             "outputs": [ {
-                                                                                               "address": 5372,
+                                                                                               "address": 5366,
                                                                                            "description": "position of the potentiometer",
                                                                                                   "mask": 65535,
                                                                                              "max_value": 65535,
@@ -7885,7 +7821,7 @@
                                                                               "identifier": "SIGHTS_FOR_CIVIL",
                                                                                   "inputs": [  ],
                                                                                  "outputs": [ {
-                                                                                                    "address": 5418,
+                                                                                                    "address": 5414,
                                                                                                 "description": "gauge position",
                                                                                                        "mask": 65535,
                                                                                                   "max_value": 65535,

--- a/src/control-reference-json/UH-1H.json
+++ b/src/control-reference-json/UH-1H.json
@@ -4988,15 +4988,12 @@
                                                                                  "physical_variant": "toggle_switch"
                                                                           },
                                                                "HDG_SET": {
+                                                                               "api_variant": "multiturn",
                                                                                   "category": "Front Dash",
-                                                                              "control_type": "limited_dial",
+                                                                              "control_type": "analog_dial",
                                                                                "description": "HDG SET Knob",
                                                                                 "identifier": "HDG_SET",
                                                                                     "inputs": [ {
-                                                                                                  "description": "set the position of the dial",
-                                                                                                    "interface": "set_state",
-                                                                                                    "max_value": 65535
-                                                                                              }, {
                                                                                                      "description": "turn the dial left or right",
                                                                                                        "interface": "variable_step",
                                                                                                        "max_value": 65535,
@@ -5004,24 +5001,21 @@
                                                                                               } ],
                                                                                    "outputs": [ {
                                                                                                       "address": 5390,
-                                                                                                  "description": "position of the potentiometer",
+                                                                                                  "description": "the rotation of the knob in the cockpit (not the value that is controlled by this knob!)",
                                                                                                          "mask": 65535,
                                                                                                     "max_value": 65535,
                                                                                                      "shift_by": 0,
-                                                                                                       "suffix": "",
+                                                                                                       "suffix": "_KNOB_POS",
                                                                                                          "type": "integer"
                                                                                               } ]
                                                                           },
                                                               "HDG_SYNC": {
+                                                                               "api_variant": "multiturn",
                                                                                   "category": "Front Dash",
-                                                                              "control_type": "limited_dial",
+                                                                              "control_type": "analog_dial",
                                                                                "description": "Compass Synchronizing",
                                                                                 "identifier": "HDG_SYNC",
                                                                                     "inputs": [ {
-                                                                                                  "description": "set the position of the dial",
-                                                                                                    "interface": "set_state",
-                                                                                                    "max_value": 65535
-                                                                                              }, {
                                                                                                      "description": "turn the dial left or right",
                                                                                                        "interface": "variable_step",
                                                                                                        "max_value": 65535,
@@ -5029,11 +5023,11 @@
                                                                                               } ],
                                                                                    "outputs": [ {
                                                                                                       "address": 5392,
-                                                                                                  "description": "position of the potentiometer",
+                                                                                                  "description": "the rotation of the knob in the cockpit (not the value that is controlled by this knob!)",
                                                                                                          "mask": 65535,
                                                                                                     "max_value": 65535,
                                                                                                      "shift_by": 0,
-                                                                                                       "suffix": "",
+                                                                                                       "suffix": "_KNOB_POS",
                                                                                                          "type": "integer"
                                                                                               } ]
                                                                           },

--- a/src/dcs-lua/lib/A10C.lua
+++ b/src/dcs-lua/lib/A10C.lua
@@ -332,7 +332,7 @@ defineFloat("FUEL_QTY_10000", 90, {0, 1}, "Fuel Panel", "Fuel Quantity Counter 1
 defineFloat("FUEL_QTY_1000", 91, {0, 1}, "Fuel Panel", "Fuel Quantity Counter 1000")
 defineFloat("FUEL_QTY_100", 92, {0, 1}, "Fuel Panel", "Fuel Quantity Counter 100")
 
-defineFloat("CANOPY_VALUE", 7, {0.0, 1.0}, "Misc", "Canopy Position")
+--defineFloat("CANOPY_VALUE", 7, {0.0, 1.0}, "Misc", "Canopy Position")
 
 defineIndicatorLight("MASTER_CAUTION", 404, "UFC", "Master Caution Light")
 
@@ -822,10 +822,10 @@ definePushButton("TISL_ENTER", 57, 3010, 628, "TISL Panel", "TISL ENTER")
 definePushButton("TISL_BITE", 57, 3011, 632, "TISL Panel", "TISL BITE")
 --definePushButton("TISL_OVERTEMP", 57, 3012, 630, "TISL Panel", "TISL OVER TEMP")
 --definePushButton("TISL_TRACK", 57, 3013, 634, "TISL Panel", "TISL TRACK")
-defineIndicatorLight("TISL_ENTER_L", 629, "TISL Panel", "TISL ENTER Light")
-defineIndicatorLight("TISL_OVERTEMP_L", 631, "TISL Panel", "TISL OVER TEMP Light")
-defineIndicatorLight("TISL_BITE_L", 633, "TISL Panel", "TISL BITE Light")
-defineIndicatorLight("TISL_TRACK_L", 635, "TISL Panel", "TISL TRACK Light")
+-- defineIndicatorLight("TISL_ENTER_L", 629, "TISL Panel", "TISL ENTER Light")
+-- defineIndicatorLight("TISL_OVERTEMP_L", 631, "TISL Panel", "TISL OVER TEMP Light")
+-- defineIndicatorLight("TISL_BITE_L", 633, "TISL Panel", "TISL BITE Light")
+-- defineIndicatorLight("TISL_TRACK_L", 635, "TISL Panel", "TISL TRACK Light")
 
 
 definePushButton("EXT_STORES_JETTISON", 12, 3001, 101, "Glare Shield", "External Stores Jettison Button")

--- a/src/dcs-lua/lib/AV8BNA.lua
+++ b/src/dcs-lua/lib/AV8BNA.lua
@@ -153,7 +153,7 @@ definePushButton("M_Warning", 35, 3199, 199,"Master Warning Panel" , "Master War
 
 -- Fuel Quantity Indicator
 defineMultipositionSwitch("FUEL_SEL", 21, 3379, 379, 7, 0.33,"Fuel Panel" ,"Fuel Totalizer Selector OUTBD/INBD/WING/INT/TOT/FEED/BIT")
-definePotentiometer("BINGO_SET", 21, 3380, 380, {0, 1},"Fuel Panel" , "Bingo Fuel Set Knob")
+defineAV8BCommSelector("BINGO_SET", 21, 3380, 0.01, 380, "Fuel Panel" , "Bingo Fuel Set Knob")
 
 -- MPCD left
 definePushButton("MPCD_L_1", 26, 3200, 200,"MPCD Left" , "MPCD Left Button 1")

--- a/src/dcs-lua/lib/UH1H.lua
+++ b/src/dcs-lua/lib/UH1H.lua
@@ -177,23 +177,17 @@ defineFloat("RALT_HI_IDX", 466, {0, 1}, "Radar Altimeter", "HI Index")
 
 local function getRadarAlt()
     local function a(n) return GetDevice(0):get_argument_value(n) end
-    local digit1 = string.format("%.0f", GetDevice(0):get_argument_value(468)*10)
+    local digit1 = string.format("%.0f", a(468)*10)
     if digit1 == "10" then digit1 = " " end
-    local digit2 = string.format("%.0f", GetDevice(0):get_argument_value(469)*10)
+    local digit2 = string.format("%.0f", a(469)*10)
     if digit2 == "10" then digit2 = " " end
-    local digit3 = string.format("%.0f", GetDevice(0):get_argument_value(470)*10)
+    local digit3 = string.format("%.0f", a(470)*10)
     if digit3 == "10" then digit3 = " " end
-    local digit4 = string.format("%.0f", GetDevice(0):get_argument_value(471)*10)
+    local digit4 = string.format("%.0f", a(471)*10)
     if digit4 == "10" then digit4 = " " end
-    return tonumber(digit1 .. digit2 .. digit3 .. digit4)
+    return digit1 .. digit2 .. digit3 .. digit4
 end
-defineIntegerFromGetter("RALT_DISPLAY", getRadarAlt, 65000, "Radar Altimeter", "Radar Altitude Display")
-
-defineFloat("RALT_DIGIT_1", 468, {0, 1}, "Radar Altimeter", "Radar Altimeter 1.Digit")
-defineFloat("RALT_DIGIT_2", 469, {0, 1}, "Radar Altimeter", "Radar Altimeter 2.Digit")
-defineFloat("RALT_DIGIT_3", 470, {0, 1}, "Radar Altimeter", "Radar Altimeter 3.Digit")
-defineFloat("RALT_DIGIT_4", 471, {0, 1}, "Radar Altimeter", "Radar Altimeter 4.Digit")
-
+defineString("RALT_DISPLAY", getRadarAlt, 4, "Radar Altimeter", "Display")
 -- clickabledata.lua:
 
 
@@ -443,8 +437,17 @@ defineTumb("DOME_LIGHT_SW", 7, 3021, 226, 1, {-1, 1}, nil, false, "Overhead Pane
 
 defineMultipositionSwitch("BLEED_AIR_SW", 47, 3001, 236, 5, 0.1, "Overhead Panel", "Bleed Air Dial")
 
-defineRotary("HDG_SET", 10, 3003, 163, "Front Dash", "HDG SET Knob")
-defineRotary("HDG_SYNC", 10, 3005, 161, "Front Dash", "Compass Synchronizing")
+-- local dummmy = moduleBeingDefined.memoryMap:allocateInt {
+--     maxValue = 65535
+-- }
+-- local dummmy = moduleBeingDefined.memoryMap:allocateInt {
+--     maxValue = 65535
+-- }
+-- defineRotary("HDG_SET", 10, 3003, 163, "Front Dash", "HDG SET Knob")
+
+-- defineRotary("HDG_SYNC", 10, 3005, 161, "Front Dash", "Compass Synchronizing")
+definePotentiometer("HDG_SET", 10, 3003, 163, {0, 1}, "Front Dash", "HDG SET Knob")
+definePotentiometer("HDG_SYNC", 10, 3005, 161, {0, 1}, "Front Dash", "Compass Synchronizing")
 defineToggleSwitch("ADF_VOR_SW", 10, 3004, 164, "Front Dash", "ADF / VOR Switch: VOR / ADF")
 defineToggleSwitch("GYRO_MODE_SW", 10, 3002, 241, "Front Dash", "DG / Slave Gyro Mode: MAG / DG")
 
@@ -481,25 +484,21 @@ defineToggleSwitch("CM_ARM_SW", 50, 3005, 456, "Countermeasures", "SAFE / ARMED 
 defineToggleSwitch("CM_MAN_PGRM_SW", 50, 3009, 459, "Countermeasures", "MAN / PGRM Switch")
 definePushButton("CM_FLARE_BTN", 50, 3006, 464, "Countermeasures", "Flare Button")
 definePushButton("CM_ARMED_TEST", 50, 3010, 457, "Countermeasures", "Armed Lamp Test")
-
+defineString("CM_FLARECNT_DISPLAY", getFlareCount, 2, "Countermeasures", "Flare Counter")
 definePushButton("CM_FLARECNT_RESET", 50, 3003, 453, "Countermeasures", "Flare Counter Reset Button")
 local function getFlareCount()
     local function a(n) return GetDevice(0):get_argument_value(n) end
-    local digit1 = string.format("%.0f", GetDevice(0):get_argument_value(460)*10)
-    local digit2 = string.format("%.0f", GetDevice(0):get_argument_value(461)*10)
-    return tonumber(digit1 .. digit2)
+    return string.format("%.0f%.0f", a(462)*10, a(463)*10)
 end
-defineIntegerFromGetter("CM_FLARECNT_DISPLAY", getFlareCount, 60, "Countermeasures", "Flare Counter Display")
+
 defineFixedStepInput("CM_FLARECNT", 50, 3004, {-1, 1}, "Countermeasures", "Flare Counter Decrease/Increase")
 
 definePushButton("CM_CHAFFCNT_RESET", 50, 3007, 455, "Countermeasures", "Chaff Counter Reset Button")
 local function getChaffCount()
     local function a(n) return GetDevice(0):get_argument_value(n) end
-    local digit1 = string.format("%.0f", GetDevice(0):get_argument_value(462)*10)
-    local digit2 = string.format("%.0f", GetDevice(0):get_argument_value(463)*10)
-    return tonumber(digit1 .. digit2)
+    return string.format("%.0f%.0f", a(462)*10, a(463)*10)
 end
-defineIntegerFromGetter("CM_CHAFFCNT_DISPLAY", getChaffCount, 60, "Countermeasures", "Chaff Counter Display")
+defineString("CM_CHAFFCNT_DISPLAY", getChaffCount, 2, "Countermeasures", "Chaff Counter")
 defineFixedStepInput("CM_CHAFFCNT", 50, 3008, {-1, 1}, "Countermeasures", "Chaff Counter Decrease/Increase")
 
 defineToggleSwitch("RADAR_ALT_PWR", 13, 3007, 449, "Overhead Panel", "Radar Altimeter Power")

--- a/src/dcs-lua/lib/UH1H.lua
+++ b/src/dcs-lua/lib/UH1H.lua
@@ -437,17 +437,8 @@ defineTumb("DOME_LIGHT_SW", 7, 3021, 226, 1, {-1, 1}, nil, false, "Overhead Pane
 
 defineMultipositionSwitch("BLEED_AIR_SW", 47, 3001, 236, 5, 0.1, "Overhead Panel", "Bleed Air Dial")
 
--- local dummmy = moduleBeingDefined.memoryMap:allocateInt {
---     maxValue = 65535
--- }
--- local dummmy = moduleBeingDefined.memoryMap:allocateInt {
---     maxValue = 65535
--- }
--- defineRotary("HDG_SET", 10, 3003, 163, "Front Dash", "HDG SET Knob")
-
--- defineRotary("HDG_SYNC", 10, 3005, 161, "Front Dash", "Compass Synchronizing")
-definePotentiometer("HDG_SET", 10, 3003, 163, {0, 1}, "Front Dash", "HDG SET Knob")
-definePotentiometer("HDG_SYNC", 10, 3005, 161, {0, 1}, "Front Dash", "Compass Synchronizing")
+defineRotary("HDG_SET", 10, 3003, 163, "Front Dash", "HDG SET Knob")
+defineRotary("HDG_SYNC", 10, 3005, 161, "Front Dash", "Compass Synchronizing")
 defineToggleSwitch("ADF_VOR_SW", 10, 3004, 164, "Front Dash", "ADF / VOR Switch: VOR / ADF")
 defineToggleSwitch("GYRO_MODE_SW", 10, 3002, 241, "Front Dash", "DG / Slave Gyro Mode: MAG / DG")
 


### PR DESCRIPTION
* fix bingo fuel selector in AV8BNA
* revert some changes to A-10C and UH-1H profiles to make the output addresses compatible with v0.7.1 again
* A-10C: remove Canopy Position, TISL ENTER Light, TISL OVER TEMP Light, TISL BITE Light, TISL TRACK Light
* UH-1H: change radar altimeter display, chaff and flare counts back to a string exports