### PR TITLE
Add optional "threshold" parameter to BIOS.util.defineIndicatorLight() in lua code to fix M2000C module

### DIFF
--- a/src/dcs-lua/lib/Util.lua
+++ b/src/dcs-lua/lib/Util.lua
@@ -275,14 +275,15 @@ function BIOS.util.MemoryMap:allocateString(args)
 end
 
 
-function BIOS.util.defineIndicatorLight(msg, arg_number, category, description)
+function BIOS.util.defineIndicatorLight(msg, arg_number, category, description, threshold)
 	--moduleBeingDefined.highFrequencyMap[msg] = function(dev0) return string.format("%.0f", dev0:get_argument_value(arg_number)) end
+	threshold = threshold or 0.5  -- Set default on/off threshold value
 	local value = moduleBeingDefined.memoryMap:allocateInt {
 		maxValue = 1
 	}
 	assert(value.shiftBy ~= nil)
 	moduleBeingDefined.exportHooks[#moduleBeingDefined.exportHooks+1] = function(dev0)
-		if dev0:get_argument_value(arg_number) < 0.5 then
+		if dev0:get_argument_value(arg_number) < threshold then
 			value:setValue(0)
 		else
 			value:setValue(1)


### PR DESCRIPTION
The M2000C module has lights that do not switch on/off at the default parameter value 0.5 and therefore they are not working. In order to fix that I have added an optional "threshold" parameter to BIOS.util.defineIndicatorLight() that defaults to 0.5, being this change compatible with the old code.
If/when this pull is approved, I will update the M2000C module to fix the non working lights that use this function.
